### PR TITLE
User-provided type declarations for JSR compatibility

### DIFF
--- a/examples/deno-server/schema.ts
+++ b/examples/deno-server/schema.ts
@@ -11,10 +11,24 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import '@hotsauce/core/extend';
+import type { CmsColumnOptions, CmsTableOptions } from '@hotsauce/core/extend';
+
+// ─────────────────────────────────────────────────────────────
+// Type declarations for $cms() method on Drizzle columns/tables.
+// Required for TypeScript support. Add once per project.
+// ─────────────────────────────────────────────────────────────
+declare module 'drizzle-orm/pg-core' {
+  interface PgColumnBuilder {
+    $cms(options: CmsColumnOptions): this;
+  }
+  interface PgTable {
+    $cms(options: CmsTableOptions): this;
+  }
+}
 
 import { z } from 'zod/v4';
 import { createInsertSchema, createUpdateSchema } from 'drizzle-zod';
-import type { Parsers } from '../../packages/handlers/mod.ts';
+import type { Parsers } from '@hotsauce/cms';
 
 /**
  * Users table

--- a/examples/deno-server/seed.ts
+++ b/examples/deno-server/seed.ts
@@ -6,7 +6,7 @@ import {
   generateTOTPSecret,
   generateTOTPUri,
   hashPassword,
-} from '../../packages/handlers/mod.ts';
+} from '@hotsauce/auth';
 import qrcode from 'qrcode-generator';
 
 // Database connection (persisted to ./data)

--- a/examples/hono-fullstack/schema.ts
+++ b/examples/hono-fullstack/schema.ts
@@ -13,8 +13,25 @@ import { relations } from 'drizzle-orm';
 import { createInsertSchema, createUpdateSchema } from 'drizzle-zod';
 
 import '@hotsauce/core/extend';
-import type { FileReference } from '@hotsauce/core';
+import type {
+  CmsColumnOptions,
+  CmsTableOptions,
+  FileReference,
+} from '@hotsauce/core/extend';
 import type { Parsers } from '@hotsauce/cms';
+
+// ─────────────────────────────────────────────────────────────
+// Type declarations for $cms() method on Drizzle columns/tables.
+// Required for TypeScript support. Add once per project.
+// ─────────────────────────────────────────────────────────────
+declare module 'drizzle-orm/pg-core' {
+  interface PgColumnBuilder {
+    $cms(options: CmsColumnOptions): this;
+  }
+  interface PgTable {
+    $cms(options: CmsTableOptions): this;
+  }
+}
 
 // ─────────────────────────────────────────────────────────────
 // Tables

--- a/packages/cms/tests/frontend_url_test.ts
+++ b/packages/cms/tests/frontend_url_test.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../core/extend/drizzle.d.ts" />
+
 // Integration tests for frontendUrl ($cms table option)
 
 import { assertEquals } from '@std/assert';

--- a/packages/cms/tests/integration_helpers.ts
+++ b/packages/cms/tests/integration_helpers.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../core/extend/drizzle.d.ts" />
+
 // Shared helpers and schemas for integration tests
 // This module is used by all integration test files
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -100,6 +100,49 @@ console.log(field.column); // Original column metadata
 Optionally patch Drizzle column builders to attach CMS-specific metadata to columns.
 This enables schema-authored hints (like file fields) to flow into introspection and field mapping.
 
+**Setup (required for TypeScript):**
+
+Add type declarations to your schema file (one-time setup per project):
+
+```ts
+// schema.ts (or a separate cms-types.d.ts file)
+import '@hotsauce/core/extend';
+import type { CmsColumnOptions, CmsTableOptions } from '@hotsauce/core/extend';
+
+// For PostgreSQL:
+declare module 'drizzle-orm/pg-core' {
+  interface PgColumnBuilder {
+    $cms(options: CmsColumnOptions): this;
+  }
+  interface PgTable {
+    $cms(options: CmsTableOptions): this;
+  }
+}
+
+// For SQLite:
+declare module 'drizzle-orm/sqlite-core' {
+  interface SQLiteColumnBuilder {
+    $cms(options: CmsColumnOptions): this;
+  }
+  interface SQLiteTable {
+    $cms(options: CmsTableOptions): this;
+  }
+}
+
+// For MySQL:
+declare module 'drizzle-orm/mysql-core' {
+  interface MySqlColumnBuilder {
+    $cms(options: CmsColumnOptions): this;
+  }
+  interface MySqlTable {
+    $cms(options: CmsTableOptions): this;
+  }
+}
+```
+
+> **Why?** JSR doesn't allow packages to augment external modules. The runtime
+> patching works, but TypeScript needs these declarations in your project.
+
 **Usage:**
 
 ```ts

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@hotsauce/core",
   "version": "0.1.0",
+  "license": "MIT",
   "exports": {
     ".": "./mod.ts",
     "./extend": "./extend/mod.ts"
@@ -14,6 +15,9 @@
       "validation/",
       "README.md",
       "LICENSE"
+    ],
+    "exclude": [
+      "extend/drizzle.d.ts"
     ]
   }
 }

--- a/packages/core/extend/mod.ts
+++ b/packages/core/extend/mod.ts
@@ -4,9 +4,8 @@
 // so schema definitions can attach CMS metadata that flows from builder → column.
 // It also patches table classes to allow table-level CMS configuration.
 //
-// Type declarations are in drizzle.d.ts (separate file for JSR compatibility).
-
-/// <reference path="./drizzle.d.ts" />
+// For TypeScript support, users must add type declarations to their project.
+// See README or copy from extend/drizzle.d.ts
 
 import { MySqlColumnBuilder } from 'drizzle-orm/mysql-core';
 import { PgColumnBuilder } from 'drizzle-orm/pg-core';

--- a/packages/core/tests/extend_cms_test.ts
+++ b/packages/core/tests/extend_cms_test.ts
@@ -1,3 +1,5 @@
+/// <reference path="../extend/drizzle.d.ts" />
+
 import { assertEquals, assertExists } from '@std/assert';
 
 // Importing this module patches Drizzle's column builder prototypes.


### PR DESCRIPTION
- Remove declare module blocks from published code (JSR rejects them)
- Keep drizzle.d.ts for internal tests only (excluded from publish)
- Tests use triple-slash reference to drizzle.d.ts
- Users add declarations to their project (documented in README)
- Fix example imports to use @hotsauce/cms and @hotsauce/auth