### PR TITLE
fix: SQLite text columns with maxLength ≤255 show in list view

### DIFF
--- a/packages/core/fields/mapping.ts
+++ b/packages/core/fields/mapping.ts
@@ -103,6 +103,11 @@ export function mapColumnToFieldType(column: IntrospectedColumn): CMSFieldType {
       // columnType patterns for long text (database-agnostic patterns)
       const longTextPatterns = /Text|Clob|MediumText|LongText/i;
       if (longTextPatterns.test(column.columnType)) {
+        // If column has a short maxLength (≤255), treat as short text (shows in list views)
+        // This handles SQLite where all text columns are SQLiteText regardless of length
+        if (column.maxLength !== undefined && column.maxLength <= 255) {
+          return 'text';
+        }
         return 'textarea';
       }
     }

--- a/packages/core/tests/mapping_test.ts
+++ b/packages/core/tests/mapping_test.ts
@@ -135,6 +135,41 @@ Deno.test('mapColumnToFieldType: long text types map to textarea', () => {
   assertEquals(mapColumnToFieldType(sqliteColumn), 'textarea');
 });
 
+Deno.test('mapColumnToFieldType: SQLite text with maxLength maps to text (not textarea)', () => {
+  // SQLite uses SQLiteText for all text columns, but columns with a short maxLength
+  // (e.g., title with 200 chars) should map to 'text' so they show in list views
+  const shortTextColumn = createMockColumn({
+    dataType: 'string',
+    columnType: 'SQLiteText',
+    maxLength: 200,
+  });
+  assertEquals(mapColumnToFieldType(shortTextColumn), 'text');
+
+  // maxLength at boundary (255) should still be text
+  const boundaryColumn = createMockColumn({
+    dataType: 'string',
+    columnType: 'SQLiteText',
+    maxLength: 255,
+  });
+  assertEquals(mapColumnToFieldType(boundaryColumn), 'text');
+
+  // maxLength > 255 should be textarea (too long for list view)
+  const mediumTextColumn = createMockColumn({
+    dataType: 'string',
+    columnType: 'SQLiteText',
+    maxLength: 500,
+  });
+  assertEquals(mapColumnToFieldType(mediumTextColumn), 'textarea');
+
+  // But unlimited text (no maxLength) should still be textarea
+  const longTextColumn = createMockColumn({
+    dataType: 'string',
+    columnType: 'SQLiteText',
+    // no maxLength
+  });
+  assertEquals(mapColumnToFieldType(longTextColumn), 'textarea');
+});
+
 Deno.test('mapColumnToFieldType: uuid columns map to uuid', () => {
   const column = createMockColumn({
     dataType: 'string',


### PR DESCRIPTION
## Problem

SQLite uses `SQLiteText` for all text columns regardless of length constraint. The field mapper was treating all `SQLiteText` columns as `textarea`, which meant they were hidden from list views.

## Solution

Check `maxLength` to distinguish short text (≤255) from long text:
- Columns with `maxLength ≤ 255` → `text` field → shown in list view
- Columns with `maxLength > 255` or no limit → `textarea` → hidden from list view

## Example

```typescript
// schema-sqlite.ts
title: text('title', { length: 200 })   // → text (shown in list)
excerpt: text('excerpt', { length: 500 }) // → textarea (hidden)
body: text('body')                        // → textarea (hidden)
```