### PR TITLE
feat: route-level CSP on PluginRoute, styleSrc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ interface TableParsers {
 - [ ] Media library UI (browse, search, reuse previously uploaded files)
 - [ ] Native CDN support (public + private files, cache invalidation)
 - [ ] Plugin config - timeout, worker response validation, load testing
+- [ ] Plugin permission approval (env var hash or DB table gate for CSP/capability changes)
 - [ ] Plugin data obfuscation (PII/credential redaction)
 - [ ] Audit logging
 - [ ] 2FA backup codes (recovery codes for lost authenticator)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,8 @@ form-action 'self';
 frame-ancestors 'none'
 ```
 
+Directives can be extended globally via the `csp` option (e.g., `imgSrc`, `connectSrc`, `styleSrc`). Plugins can also declare route-level CSP overrides that are merged with the global policy at startup — only the specific route is relaxed.
+
 **Best Practices:**
 
 ```typescript

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,7 @@ form-action 'self';
 frame-ancestors 'none'
 ```
 
-Directives can be extended globally via the `csp` option (e.g., `imgSrc`, `connectSrc`, `styleSrc`). Plugins can also declare route-level CSP overrides that are merged with the global policy at startup — only the specific route is relaxed.
+Directives can be extended globally via the `csp` option (e.g., `imgSrc`, `connectSrc`, `styleSrc`). Plugins can also declare route-level CSP overrides for `styleSrc` and `connectSrc`, which are merged with the global policy at startup — only the specific route is relaxed.
 
 **Best Practices:**
 

--- a/apps/demo/admin/admin.ts
+++ b/apps/demo/admin/admin.ts
@@ -58,10 +58,8 @@ export function createAdminHandler(db: Database) {
     storage: s3
       ? (ctx) => ctx.column === 'avatar' ? undefined : 's3'
       : undefined,
-    // Allow S3/MinIO endpoint for uploads (connectSrc) and image previews (imgSrc)
-    csp: s3
-      ? { connectSrc: [s3.publicEndpoint], imgSrc: [s3.publicEndpoint] }
-      : undefined,
+    // Allow S3/MinIO images on CMS edit/detail pages (connectSrc handled by plugin)
+    csp: s3 ? { imgSrc: [s3.publicEndpoint] } : undefined,
     onError: (error, context) =>
       // deno-lint-ignore no-console
       console.error('CMS Error:', { error, context }),

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
   // Workspace configuration for hotsauce-cms monorepo
   "name": "@hotsauce/workspace",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": "./packages/core/mod.ts",
 
   // Use local node_modules for npm packages (enables fine-grained permissions)

--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/auth",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": "./mod.ts",
   "publish": {
     "include": [

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -513,7 +513,7 @@ Customize CSP per-directive via the `csp` option:
 ```ts
 csp: {
   imgSrc: ['https://my-bucket.s3.amazonaws.com'],
-  connectSrc: ['https://my-bucket.s3.amazonaws.com'],
+  connectSrc: ['https://api.example.com'],
   styleSrc: ["'unsafe-inline'"], // Only if needed (e.g., runtime style injection)
 }
 ```
@@ -530,6 +530,13 @@ Plugins can declare CSP overrides on individual routes via `PluginRoute.csp`. Ro
   pattern: ':table/:id/:column',
   handler: (ctx) => renderEditor(ctx),
   csp: { styleSrc: ["'unsafe-inline'"] },
+}
+
+// Plugin route that needs to fetch from an external origin
+{
+  pattern: ':table/:id/:column',
+  handler: (ctx) => renderUploadPage(ctx),
+  csp: { connectSrc: ['https://s3.us-east-1.amazonaws.com'] },
 }
 ```
 

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -508,6 +508,31 @@ This policy:
 - Blocks the CMS from being embedded in iframes (clickjacking protection)
 - Limits referrer information leakage
 
+Customize CSP per-directive via the `csp` option:
+
+```ts
+csp: {
+  imgSrc: ['https://my-bucket.s3.amazonaws.com'],
+  connectSrc: ['https://my-bucket.s3.amazonaws.com'],
+  styleSrc: ["'unsafe-inline'"], // Only if needed (e.g., runtime style injection)
+}
+```
+
+`styleSrc` accepts CSP keywords (`'unsafe-inline'`, `'unsafe-hashes'`), hash sources (`'sha256-...'`), nonce sources (`'nonce-...'`), and URL origins. `'unsafe-eval'` is blocked.
+
+#### Route-Level CSP (Plugins)
+
+Plugins can declare CSP overrides on individual routes via `PluginRoute.csp`. These are merged with the global CSP at startup — only that specific route gets the extra sources. Other routes remain strict.
+
+```ts
+// Plugin route with relaxed style-src (only for this route)
+{
+  pattern: ':table/:id/:column',
+  handler: (ctx) => renderEditor(ctx),
+  csp: { styleSrc: ["'unsafe-inline'"] },
+}
+```
+
 ### CSRF Protection
 
 Forms include CSRF tokens validated on POST. See `csrf.ts` exports.
@@ -758,7 +783,7 @@ createCmsHandler({
 | `parsers`         | `Parsers`                                                 | auto-gen     | Custom Zod parsers per table (overrides drizzle-zod)                                   |
 | `plugins`         | `PluginConfig[]`                                          | —            | Plugins (UI overrides, transforms, action hooks)                                       |
 | `storage`         | `string \| (ctx) => string \| undefined`                  | —            | Storage routing: provider ID or resolver function                                      |
-| `csp`             | `CspOptions`                                              | —            | Additional CSP origins (`imgSrc`, `connectSrc`, `frameSrc`)                            |
+| `csp`             | `CspOptions`                                              | —            | Additional CSP sources (`imgSrc`, `connectSrc`, `frameSrc`, `styleSrc`)                |
 | `isAuthenticated` | `(request: Request) => boolean \| Promise<boolean>`       | —            | Legacy: custom auth check (prefer `auth` option)                                       |
 | `canAccess`       | `(request, table, action) => boolean \| Promise<boolean>` | —            | Legacy: custom per-table authorization                                                 |
 

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -522,7 +522,7 @@ csp: {
 
 #### Route-Level CSP (Plugins)
 
-Plugins can declare CSP overrides on individual routes via `PluginRoute.csp`. Route directives are combined with the global CSP at startup — if both the global config and a route set the same directive, the route's value **replaces** the global one for that directive. Other directives are inherited from the global config.
+Plugins can declare additional CSP sources on individual routes via `PluginRoute.csp`. Route sources are **concatenated** with the global CSP at startup — the route's values are appended to the global directive arrays, so both global and route-level sources apply. Directives not specified on the route inherit the global values unchanged.
 
 ```ts
 // Plugin route with relaxed style-src (only for this route)

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -522,7 +522,7 @@ csp: {
 
 #### Route-Level CSP (Plugins)
 
-Plugins can declare CSP overrides on individual routes via `PluginRoute.csp`. These are merged with the global CSP at startup — only that specific route gets the extra sources. Other routes remain strict.
+Plugins can declare CSP overrides on individual routes via `PluginRoute.csp`. Route directives are combined with the global CSP at startup — if both the global config and a route set the same directive, the route's value **replaces** the global one for that directive. Other directives are inherited from the global config.
 
 ```ts
 // Plugin route with relaxed style-src (only for this route)

--- a/packages/cms/deno.json
+++ b/packages/cms/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/cms",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": "./mod.ts",
   "publish": {
     "include": [

--- a/packages/cms/http.ts
+++ b/packages/cms/http.ts
@@ -27,14 +27,14 @@ import type { CspOptions } from './types.ts';
 export function buildSecurityHeaders(
   csp?: CspOptions,
 ): Record<string, string> {
-  const imgSrc = `img-src 'self' data:${joinOrigins(csp?.imgSrc)}`;
+  const imgSrc = `img-src 'self' data:${joinCspValues(csp?.imgSrc)}`;
   const connectSrc = csp?.connectSrc?.length
-    ? `connect-src 'self'${joinOrigins(csp.connectSrc)}; `
+    ? `connect-src 'self'${joinCspValues(csp.connectSrc)}; `
     : '';
   const frameSrc = csp?.frameSrc?.length
-    ? `frame-src 'self'${joinOrigins(csp.frameSrc)}; `
+    ? `frame-src 'self'${joinCspValues(csp.frameSrc)}; `
     : '';
-  const styleSrc = `style-src 'self'${joinOrigins(csp?.styleSrc)}`;
+  const styleSrc = `style-src 'self'${joinCspValues(csp?.styleSrc)}`;
 
   return {
     'Content-Security-Policy':
@@ -46,11 +46,11 @@ export function buildSecurityHeaders(
 }
 
 /**
- * Normalize a CSP source to an origin.
- * URLs with paths are stripped to just the origin (CSP ignores paths for most directives).
- * Non-URL values (like 'self' or blob:) are returned as-is.
+ * Normalize a CSP source value.
+ * URL sources are stripped to just the origin (CSP ignores paths for most directives).
+ * Non-URL values (keywords like 'unsafe-inline', hashes, nonces) are returned as-is.
  */
-function normalizeOrigin(source: string): string {
+function normalizeCspValue(source: string): string {
   try {
     const url = new URL(source);
     return url.origin;
@@ -59,9 +59,9 @@ function normalizeOrigin(source: string): string {
   }
 }
 
-function joinOrigins(origins?: string[]): string {
-  if (!origins?.length) return '';
-  return ' ' + origins.map(normalizeOrigin).join(' ');
+function joinCspValues(sources?: string[]): string {
+  if (!sources?.length) return '';
+  return ' ' + sources.map(normalizeCspValue).join(' ');
 }
 
 /** Default security headers (no CSP extensions) */

--- a/packages/cms/http.ts
+++ b/packages/cms/http.ts
@@ -47,7 +47,7 @@ export function buildSecurityHeaders(
 
 /**
  * Normalize a CSP source value.
- * URL sources are stripped to just the origin (CSP ignores paths for most directives).
+ * URL sources are reduced to the origin (scheme + host + port).
  * Non-URL values (keywords like 'unsafe-inline', hashes, nonces) are returned as-is.
  */
 function normalizeCspValue(source: string): string {

--- a/packages/cms/http.ts
+++ b/packages/cms/http.ts
@@ -34,10 +34,11 @@ export function buildSecurityHeaders(
   const frameSrc = csp?.frameSrc?.length
     ? `frame-src 'self'${joinOrigins(csp.frameSrc)}; `
     : '';
+  const styleSrc = `style-src 'self'${joinOrigins(csp?.styleSrc)}`;
 
   return {
     'Content-Security-Policy':
-      `default-src 'self'; style-src 'self'; script-src 'self'; ${connectSrc}${frameSrc}${imgSrc}; form-action 'self'; frame-ancestors 'none'`,
+      `default-src 'self'; ${styleSrc}; script-src 'self'; ${connectSrc}${frameSrc}${imgSrc}; form-action 'self'; frame-ancestors 'none'`,
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'strict-origin-when-cross-origin',

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -626,6 +626,11 @@ async function handlePluginRoute(
     body, // Add body to context (overrides undefined from baseCtx)
   };
 
+  // Use route-specific headers if plugin route has CSP overrides
+  const routeKey = `${plugin.name}/${route.pattern}`;
+  const effectiveHeaders = options.routeSecurityHeaders.get(routeKey) ??
+    options.securityHeaders;
+
   // Dispatch based on route type
   if (route.handler) {
     // In-process handler
@@ -636,7 +641,7 @@ async function handlePluginRoute(
         if (ct.startsWith('text/html')) {
           // Enforce all security headers for HTML responses
           // (plugins cannot override CSP, X-Frame-Options, etc.)
-          for (const [k, v] of Object.entries(options.securityHeaders)) {
+          for (const [k, v] of Object.entries(effectiveHeaders)) {
             result.headers.set(k, v);
           }
         } else {
@@ -649,7 +654,7 @@ async function handlePluginRoute(
       return new Response(result, {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
-          ...options.securityHeaders,
+          ...effectiveHeaders,
         },
       });
     } catch (error) {
@@ -681,7 +686,7 @@ async function handlePluginRoute(
       return new Response(html, {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
-          ...options.securityHeaders,
+          ...effectiveHeaders,
         },
       });
     } catch (error) {
@@ -850,6 +855,10 @@ export function createCmsHandler(options: CmsOptions): Handler {
   }
   const securityHeaders = buildSecurityHeaders(options.csp);
 
+  // Pre-compute route-specific security headers for plugin routes with CSP overrides.
+  // Each route's CSP is merged with (and extends) the global CSP.
+  const routeSecurityHeaders = new Map<string, Record<string, string>>();
+
   // Resolve policies:
   // - 'dangerously-open' → {} (full access)
   // - object → use as-is
@@ -898,6 +907,19 @@ export function createCmsHandler(options: CmsOptions): Handler {
     options.storage,
   );
 
+  // Validate and pre-compute route-specific CSP headers
+  if (pluginRegistry) {
+    for (const { pluginName, route } of pluginRegistry.getAllRoutes()) {
+      if (route.csp) {
+        validateCspOptions(route.csp);
+        routeSecurityHeaders.set(
+          `${pluginName}/${route.pattern}`,
+          buildSecurityHeaders({ ...options.csp, ...route.csp }),
+        );
+      }
+    }
+  }
+
   // Apply defaults
   const opts: ResolvedCmsOptions = {
     introspected,
@@ -914,6 +936,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
     plugins: pluginRegistry,
     storage: storageRegistry,
     securityHeaders,
+    routeSecurityHeaders,
   };
 
   // Helper to check if request accepts JSON

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -43,6 +43,7 @@ import {
   validateCsrfToken,
 } from './csrf.ts';
 import {
+  CmsConfigError,
   validateAutoDraft,
   validateCmsOptions,
   validateCspOptions,
@@ -909,8 +910,22 @@ export function createCmsHandler(options: CmsOptions): Handler {
 
   // Validate and pre-compute route-specific CSP headers
   if (pluginRegistry) {
+    const ALLOWED_ROUTE_CSP_KEYS = new Set(['styleSrc']);
     for (const { pluginName, route } of pluginRegistry.getAllRoutes()) {
       if (route.csp) {
+        const unknownKeys = Object.keys(route.csp).filter(
+          (k) => !ALLOWED_ROUTE_CSP_KEYS.has(k),
+        );
+        if (unknownKeys.length > 0) {
+          throw new CmsConfigError(
+            `Plugin '${pluginName}' route '${route.pattern}' has unsupported csp keys: ${
+              unknownKeys.join(', ')
+            }. ` +
+              `Only ${
+                [...ALLOWED_ROUTE_CSP_KEYS].join(', ')
+              } are allowed in route-level CSP.`,
+          );
+        }
         validateCspOptions(route.csp);
         routeSecurityHeaders.set(
           `${pluginName}/${route.pattern}`,

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -7,6 +7,7 @@ import { eq, sql, type Table } from 'drizzle-orm';
 import type {
   CmsOptions,
   CrudAction,
+  CspOptions,
   Handler,
   ResolvedAuthOptions,
   ResolvedCmsOptions,
@@ -628,7 +629,8 @@ async function handlePluginRoute(
   };
 
   // Use route-specific headers if plugin route has CSP overrides
-  const routeKey = `${plugin.name}/${route.pattern}`;
+  const methods = [...(route.methods ?? ['GET'])].sort().join(',');
+  const routeKey = `${plugin.name}/${route.pattern}/${methods}`;
   const effectiveHeaders = options.routeSecurityHeaders.get(routeKey) ??
     options.securityHeaders;
 
@@ -927,9 +929,21 @@ export function createCmsHandler(options: CmsOptions): Handler {
           );
         }
         validateCspOptions(route.csp);
+        const mergedCsp: CspOptions = { ...options.csp };
+        for (
+          const key of Object.keys(route.csp) as ('styleSrc' | 'connectSrc')[]
+        ) {
+          const routeValues = route.csp[key];
+          if (!routeValues?.length) continue;
+          const global = mergedCsp[key];
+          mergedCsp[key] = global?.length
+            ? [...global, ...routeValues]
+            : [...routeValues];
+        }
+        const methods = [...(route.methods ?? ['GET'])].sort().join(',');
         routeSecurityHeaders.set(
-          `${pluginName}/${route.pattern}`,
-          buildSecurityHeaders({ ...options.csp, ...route.csp }),
+          `${pluginName}/${route.pattern}/${methods}`,
+          buildSecurityHeaders(mergedCsp),
         );
       }
     }

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -910,7 +910,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
 
   // Validate and pre-compute route-specific CSP headers
   if (pluginRegistry) {
-    const ALLOWED_ROUTE_CSP_KEYS = new Set(['styleSrc']);
+    const ALLOWED_ROUTE_CSP_KEYS = new Set(['styleSrc', 'connectSrc']);
     for (const { pluginName, route } of pluginRegistry.getAllRoutes()) {
       if (route.csp) {
         const unknownKeys = Object.keys(route.csp).filter(

--- a/packages/cms/tests/http_test.ts
+++ b/packages/cms/tests/http_test.ts
@@ -554,3 +554,34 @@ Deno.test('htmlResponse: uses custom security headers when provided', () => {
   const csp = response.headers.get('Content-Security-Policy')!;
   assertEquals(csp.includes('https://s3.example.com'), true);
 });
+
+Deno.test('buildSecurityHeaders: adds styleSrc sources', () => {
+  const headers = buildSecurityHeaders({
+    styleSrc: ["'unsafe-inline'"],
+  });
+  const csp = headers['Content-Security-Policy']!;
+
+  assertEquals(
+    csp.includes("style-src 'self' 'unsafe-inline'"),
+    true,
+  );
+});
+
+Deno.test('buildSecurityHeaders: no extra style-src when styleSrc not given', () => {
+  const headers = buildSecurityHeaders();
+  const csp = headers['Content-Security-Policy']!;
+
+  assertEquals(csp.includes("style-src 'self'"), true);
+  assertEquals(csp.includes('unsafe-inline'), false);
+});
+
+Deno.test('buildSecurityHeaders: combines styleSrc with other directives', () => {
+  const headers = buildSecurityHeaders({
+    imgSrc: ['https://cdn.example.com'],
+    styleSrc: ["'unsafe-inline'"],
+  });
+  const csp = headers['Content-Security-Policy']!;
+
+  assertEquals(csp.includes("style-src 'self' 'unsafe-inline'"), true);
+  assertEquals(csp.includes('https://cdn.example.com'), true);
+});

--- a/packages/cms/tests/plugin_route_headers_test.ts
+++ b/packages/cms/tests/plugin_route_headers_test.ts
@@ -225,34 +225,41 @@ Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
   });
 });
 
-Deno.test('plugin route: rejects unknown csp keys', () => {
-  const client = new PGlite();
-  const db = drizzle(client, { schema });
+Deno.test({
+  name: 'plugin route: rejects unknown csp keys',
+  // PGlite starts async I/O on construction; we only test that config
+  // validation throws synchronously, so disable leak checks.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn() {
+    const client = new PGlite();
+    const db = drizzle(client, { schema });
 
-  assertThrows(
-    () =>
-      createCmsHandler({
-        csrfSecret: TEST_CSRF_SECRET,
-        auth: 'dangerously-open',
-        policies: 'dangerously-open',
-        db,
-        schema,
-        basePath: '/admin',
-        plugins: [
-          {
-            name: 'bad-csp',
-            filter: 'dangerously-open' as const,
-            routes: [
-              {
-                pattern: 'editor',
-                handler: () => '<h1>Bad</h1>',
-                csp: { imgSrc: ['https://evil.com'] } as never,
-              },
-            ],
-          },
-        ],
-      }),
-    Error,
-    'unsupported csp keys: imgSrc',
-  );
+    assertThrows(
+      () =>
+        createCmsHandler({
+          csrfSecret: TEST_CSRF_SECRET,
+          auth: 'dangerously-open',
+          policies: 'dangerously-open',
+          db,
+          schema,
+          basePath: '/admin',
+          plugins: [
+            {
+              name: 'bad-csp',
+              filter: 'dangerously-open' as const,
+              routes: [
+                {
+                  pattern: 'editor',
+                  handler: () => '<h1>Bad</h1>',
+                  csp: { imgSrc: ['https://evil.com'] } as never,
+                },
+              ],
+            },
+          ],
+        }),
+      Error,
+      'unsupported csp keys: imgSrc',
+    );
+  },
 });

--- a/packages/cms/tests/plugin_route_headers_test.ts
+++ b/packages/cms/tests/plugin_route_headers_test.ts
@@ -153,9 +153,14 @@ Deno.test('plugin route: route-level CSP override', async (t) => {
             handler: () => '<h1>Default CSP</h1>',
           },
           {
-            pattern: 'with-csp',
+            pattern: 'with-style-csp',
             handler: () => '<h1>Custom CSP</h1>',
             csp: { styleSrc: ["'unsafe-inline'"] },
+          },
+          {
+            pattern: 'with-connect-csp',
+            handler: () => '<h1>Upload</h1>',
+            csp: { connectSrc: ['https://s3.example.com'] },
           },
         ],
       },
@@ -170,11 +175,12 @@ Deno.test('plugin route: route-level CSP override', async (t) => {
     const csp = res.headers.get('Content-Security-Policy')!;
     assertEquals(csp.includes("style-src 'self'"), true);
     assertEquals(csp.includes('unsafe-inline'), false);
+    assertEquals(csp.includes('connect-src'), false);
   });
 
-  await t.step('route with csp gets merged style-src', async () => {
+  await t.step('route with styleSrc gets merged style-src', async () => {
     const res = await handler(
-      new Request('http://localhost/admin/csp-test/with-csp'),
+      new Request('http://localhost/admin/csp-test/with-style-csp'),
     );
     assertEquals(res.status, 200);
     const csp = res.headers.get('Content-Security-Policy')!;
@@ -182,6 +188,21 @@ Deno.test('plugin route: route-level CSP override', async (t) => {
     // Other headers still enforced
     assertEquals(res.headers.get('X-Frame-Options'), 'DENY');
     assertEquals(csp.includes("frame-ancestors 'none'"), true);
+  });
+
+  await t.step('route with connectSrc gets connect-src directive', async () => {
+    const res = await handler(
+      new Request('http://localhost/admin/csp-test/with-connect-csp'),
+    );
+    assertEquals(res.status, 200);
+    const csp = res.headers.get('Content-Security-Policy')!;
+    assertEquals(
+      csp.includes("connect-src 'self' https://s3.example.com"),
+      true,
+    );
+    // Default style-src unchanged
+    assertEquals(csp.includes("style-src 'self'"), true);
+    assertEquals(csp.includes('unsafe-inline'), false);
   });
 });
 

--- a/packages/cms/tests/plugin_route_headers_test.ts
+++ b/packages/cms/tests/plugin_route_headers_test.ts
@@ -130,3 +130,97 @@ Deno.test('plugin route: security headers', async (t) => {
     },
   );
 });
+
+Deno.test('plugin route: route-level CSP override', async (t) => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema });
+  await createBasicTables(db);
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema,
+    basePath: '/admin',
+    plugins: [
+      {
+        name: 'csp-test',
+        filter: 'dangerously-open' as const,
+        routes: [
+          {
+            pattern: 'no-csp',
+            handler: () => '<h1>Default CSP</h1>',
+          },
+          {
+            pattern: 'with-csp',
+            handler: () => '<h1>Custom CSP</h1>',
+            csp: { styleSrc: ["'unsafe-inline'"] },
+          },
+        ],
+      },
+    ],
+  });
+
+  await t.step('route without csp gets default style-src', async () => {
+    const res = await handler(
+      new Request('http://localhost/admin/csp-test/no-csp'),
+    );
+    assertEquals(res.status, 200);
+    const csp = res.headers.get('Content-Security-Policy')!;
+    assertEquals(csp.includes("style-src 'self'"), true);
+    assertEquals(csp.includes('unsafe-inline'), false);
+  });
+
+  await t.step('route with csp gets merged style-src', async () => {
+    const res = await handler(
+      new Request('http://localhost/admin/csp-test/with-csp'),
+    );
+    assertEquals(res.status, 200);
+    const csp = res.headers.get('Content-Security-Policy')!;
+    assertEquals(csp.includes("style-src 'self' 'unsafe-inline'"), true);
+    // Other headers still enforced
+    assertEquals(res.headers.get('X-Frame-Options'), 'DENY');
+    assertEquals(csp.includes("frame-ancestors 'none'"), true);
+  });
+});
+
+Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema });
+  await createBasicTables(db);
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema,
+    basePath: '/admin',
+    csp: { imgSrc: ['https://cdn.example.com'] },
+    plugins: [
+      {
+        name: 'merge-test',
+        filter: 'dangerously-open' as const,
+        routes: [
+          {
+            pattern: 'editor',
+            handler: () => '<h1>Editor</h1>',
+            csp: { styleSrc: ["'unsafe-inline'"] },
+          },
+        ],
+      },
+    ],
+  });
+
+  await t.step('route CSP includes both global and route sources', async () => {
+    const res = await handler(
+      new Request('http://localhost/admin/merge-test/editor'),
+    );
+    const csp = res.headers.get('Content-Security-Policy')!;
+    // Route's styleSrc is applied
+    assertEquals(csp.includes("style-src 'self' 'unsafe-inline'"), true);
+    // Global imgSrc is preserved
+    assertEquals(csp.includes('https://cdn.example.com'), true);
+  });
+});

--- a/packages/cms/tests/plugin_route_headers_test.ts
+++ b/packages/cms/tests/plugin_route_headers_test.ts
@@ -1,7 +1,7 @@
 // Plugin Route Security Headers Tests
 // Verifies that security headers are correctly applied to plugin route responses
 
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertThrows } from '@std/assert';
 import { PGlite } from '@electric-sql/pglite';
 import { drizzle } from 'drizzle-orm/pglite';
 import {
@@ -223,4 +223,36 @@ Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
     // Global imgSrc is preserved
     assertEquals(csp.includes('https://cdn.example.com'), true);
   });
+});
+
+Deno.test('plugin route: rejects unknown csp keys', () => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema });
+
+  assertThrows(
+    () =>
+      createCmsHandler({
+        csrfSecret: TEST_CSRF_SECRET,
+        auth: 'dangerously-open',
+        policies: 'dangerously-open',
+        db,
+        schema,
+        basePath: '/admin',
+        plugins: [
+          {
+            name: 'bad-csp',
+            filter: 'dangerously-open' as const,
+            routes: [
+              {
+                pattern: 'editor',
+                handler: () => '<h1>Bad</h1>',
+                csp: { imgSrc: ['https://evil.com'] } as never,
+              },
+            ],
+          },
+        ],
+      }),
+    Error,
+    'unsupported csp keys: imgSrc',
+  );
 });

--- a/packages/cms/tests/plugin_route_headers_test.ts
+++ b/packages/cms/tests/plugin_route_headers_test.ts
@@ -206,7 +206,7 @@ Deno.test('plugin route: route-level CSP override', async (t) => {
   });
 });
 
-Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
+Deno.test('plugin route: route CSP concatenates with global CSP', async (t) => {
   const client = new PGlite();
   const db = drizzle(client, { schema });
   await createBasicTables(db);
@@ -218,7 +218,10 @@ Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
     db,
     schema,
     basePath: '/admin',
-    csp: { imgSrc: ['https://cdn.example.com'] },
+    csp: {
+      imgSrc: ['https://cdn.example.com'],
+      styleSrc: ["'sha256-abc123='"],
+    },
     plugins: [
       {
         name: 'merge-test',
@@ -234,13 +237,16 @@ Deno.test('plugin route: route CSP merges with global CSP', async (t) => {
     ],
   });
 
-  await t.step('route CSP includes both global and route sources', async () => {
+  await t.step('route styleSrc is appended to global styleSrc', async () => {
     const res = await handler(
       new Request('http://localhost/admin/merge-test/editor'),
     );
     const csp = res.headers.get('Content-Security-Policy')!;
-    // Route's styleSrc is applied
-    assertEquals(csp.includes("style-src 'self' 'unsafe-inline'"), true);
+    // Both global and route styleSrc values present
+    assertEquals(
+      csp.includes("style-src 'self' 'sha256-abc123=' 'unsafe-inline'"),
+      true,
+    );
     // Global imgSrc is preserved
     assertEquals(csp.includes('https://cdn.example.com'), true);
   });

--- a/packages/cms/tests/validation_test.ts
+++ b/packages/cms/tests/validation_test.ts
@@ -575,6 +575,56 @@ Deno.test('validateCspOptions: reports errors for multiple directives', () => {
 });
 
 // =============================================================================
+// CSP styleSrc validation tests
+// =============================================================================
+
+Deno.test("validateCspOptions: accepts 'unsafe-inline' in styleSrc", () => {
+  validateCspOptions({ styleSrc: ["'unsafe-inline'"] });
+});
+
+Deno.test("validateCspOptions: accepts 'unsafe-hashes' in styleSrc", () => {
+  validateCspOptions({ styleSrc: ["'unsafe-hashes'"] });
+});
+
+Deno.test('validateCspOptions: accepts hash source in styleSrc', () => {
+  validateCspOptions({
+    styleSrc: ["'sha256-abc123+/='"],
+  });
+});
+
+Deno.test('validateCspOptions: accepts nonce source in styleSrc', () => {
+  validateCspOptions({
+    styleSrc: ["'nonce-abc123'"],
+  });
+});
+
+Deno.test('validateCspOptions: accepts URL origin in styleSrc', () => {
+  validateCspOptions({
+    styleSrc: ['https://fonts.googleapis.com'],
+  });
+});
+
+Deno.test("validateCspOptions: rejects 'unsafe-eval' in styleSrc", () => {
+  assertThrows(
+    () => validateCspOptions({ styleSrc: ["'unsafe-eval'"] }),
+    CmsConfigError,
+    'unsafe-eval',
+  );
+});
+
+Deno.test('validateCspOptions: rejects unrecognized CSP keyword in styleSrc', () => {
+  assertThrows(
+    () => validateCspOptions({ styleSrc: ["'bad-keyword'"] }),
+    CmsConfigError,
+    'not a recognized CSP source',
+  );
+});
+
+Deno.test('validateCspOptions: accepts empty styleSrc array', () => {
+  validateCspOptions({ styleSrc: [] });
+});
+
+// =============================================================================
 // validateAutoDraft tests
 // =============================================================================
 

--- a/packages/cms/types.ts
+++ b/packages/cms/types.ts
@@ -317,6 +317,8 @@ export interface CspOptions {
   connectSrc?: string[];
   /** Additional origins for frame-src (iframes) */
   frameSrc?: string[];
+  /** Additional sources for style-src (e.g., "'unsafe-inline'" for runtime styles) */
+  styleSrc?: string[];
 }
 
 /**
@@ -619,6 +621,8 @@ export interface ResolvedCmsOptions {
   storage?: StorageRegistry;
   /** Computed security headers (CSP + other headers), built once at startup */
   securityHeaders: Record<string, string>;
+  /** Pre-computed route-specific security headers (plugin routes with CSP overrides) */
+  routeSecurityHeaders: Map<string, Record<string, string>>;
 }
 
 /**

--- a/packages/cms/validation.ts
+++ b/packages/cms/validation.ts
@@ -367,20 +367,41 @@ export function validateAutoDraft(
  * @throws {CmsConfigError} When any origin is invalid
  */
 export function validateCspOptions(
-  csp: { imgSrc?: string[]; connectSrc?: string[]; frameSrc?: string[] },
+  csp: {
+    imgSrc?: string[];
+    connectSrc?: string[];
+    frameSrc?: string[];
+    styleSrc?: string[];
+  },
 ): void {
   const errors: string[] = [];
 
-  const directives: [string, string[] | undefined][] = [
+  // Origin-only directives (only http/https URLs allowed)
+  const originDirectives: [string, string[] | undefined][] = [
     ['imgSrc', csp.imgSrc],
     ['connectSrc', csp.connectSrc],
     ['frameSrc', csp.frameSrc],
   ];
 
-  for (const [name, origins] of directives) {
+  for (const [name, origins] of originDirectives) {
     if (!origins) continue;
     for (const origin of origins) {
       const err = validateOrigin(origin);
+      if (err) {
+        errors.push(`  - csp.${name}: ${err}`);
+      }
+    }
+  }
+
+  // Directives that also allow CSP keywords (e.g., 'unsafe-inline', hashes, nonces)
+  const sourceDirectives: [string, string[] | undefined][] = [
+    ['styleSrc', csp.styleSrc],
+  ];
+
+  for (const [name, sources] of sourceDirectives) {
+    if (!sources) continue;
+    for (const source of sources) {
+      const err = validateCspSource(source);
       if (err) {
         errors.push(`  - csp.${name}: ${err}`);
       }
@@ -411,4 +432,37 @@ function validateOrigin(origin: string): string | null {
   } catch {
     return `'${origin}' is not a valid URL origin`;
   }
+}
+
+/** Recognized CSP keyword sources */
+const CSP_KEYWORDS = new Set(["'unsafe-inline'", "'unsafe-hashes'"]);
+
+/** Pattern for CSP hash sources: 'sha256-...', 'sha384-...', 'sha512-...' */
+const CSP_HASH_RE = /^'(sha256|sha384|sha512)-[A-Za-z0-9+/]+=*'$/;
+
+/** Pattern for CSP nonce sources: 'nonce-...' */
+const CSP_NONCE_RE = /^'nonce-[A-Za-z0-9+/=_-]+'$/;
+
+/**
+ * Validate a CSP source value.
+ * Accepts URL origins AND CSP keywords/hashes/nonces.
+ * Blocks dangerous keywords like 'unsafe-eval'.
+ */
+function validateCspSource(source: string): string | null {
+  // CSP keyword (single-quoted)
+  if (source.startsWith("'") && source.endsWith("'")) {
+    if (source === "'unsafe-eval'") {
+      return `'unsafe-eval' is not allowed — it enables arbitrary code execution`;
+    }
+    if (
+      CSP_KEYWORDS.has(source) ||
+      CSP_HASH_RE.test(source) ||
+      CSP_NONCE_RE.test(source)
+    ) {
+      return null;
+    }
+    return `${source} is not a recognized CSP source`;
+  }
+  // URL origin
+  return validateOrigin(source);
 }

--- a/packages/cms/validation.ts
+++ b/packages/cms/validation.ts
@@ -2,6 +2,7 @@
 // Validates CmsOptions at startup and throws on invalid config
 
 import { z } from 'zod';
+import type { CspOptions } from './types.ts';
 
 /**
  * Zod schema for CmsOptions validation
@@ -361,18 +362,14 @@ export function validateAutoDraft(
 }
 
 /**
- * Validate CSP origin strings.
- * Each origin must be a valid http: or https: URL origin (scheme + host + optional port).
+ * Validate CSP directive values.
+ * Origin-only directives (imgSrc, connectSrc, frameSrc) must be http/https URL origins.
+ * Source directives (styleSrc) also accept CSP keywords, hashes, and nonces.
  *
- * @throws {CmsConfigError} When any origin is invalid
+ * @throws {CmsConfigError} When any value is invalid
  */
 export function validateCspOptions(
-  csp: {
-    imgSrc?: string[];
-    connectSrc?: string[];
-    frameSrc?: string[];
-    styleSrc?: string[];
-  },
+  csp: CspOptions,
 ): void {
   const errors: string[] = [];
 

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/packages/plugins/deno.json
+++ b/packages/plugins/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/plugins",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": {
     ".": "./mod.ts",
     "./audit-log": "./audit-log/mod.ts",

--- a/packages/plugins/puck/README.md
+++ b/packages/plugins/puck/README.md
@@ -145,6 +145,10 @@ export const pages = sqliteTable('pages', {
 | ------------------------------------ | ----------------------------- |
 | `GET /admin/puck/:table/:id/:column` | Puck editor page (HTML shell) |
 
+### CSP
+
+The editor route automatically declares `csp: { styleSrc: ["'unsafe-inline'"] }` because Puck/React sets inline `style` attributes on DOM elements at runtime (drag handles, overlays, positioning). This is merged with the global CSP at startup — only the editor route is relaxed; asset routes remain strict. No user configuration needed.
+
 ## Frontend Rendering (SSR)
 
 For server-side rendering of Puck content, use the `/rsc` export to avoid browser dependencies:

--- a/packages/plugins/puck/mod.ts
+++ b/packages/plugins/puck/mod.ts
@@ -265,6 +265,7 @@ export function createPuckPlugin(
         pattern: ':table/:id/:column',
         methods: ['GET'],
         handler: (ctx) => renderEditorPage(ctx, opts),
+        csp: { styleSrc: ["'unsafe-inline'"] },
       },
     ],
   };

--- a/packages/plugins/s3-storage/README.md
+++ b/packages/plugins/s3-storage/README.md
@@ -38,12 +38,12 @@ const handler = createCmsHandler({
   schema,
   plugins: [s3Plugin],
   storage: 's3', // Route file fields to this plugin
-  // Required: allow browser to upload directly to S3
-  csp: { connectSrc: [s3Endpoint] },
+  // Allow S3 images on CMS edit/detail pages
+  csp: { imgSrc: [s3Endpoint] },
 });
 ```
 
-> **Important:** You must configure `csp.connectSrc` with your S3 endpoint for uploads to work. The CMS enforces security headers — plugins cannot override them.
+The plugin automatically configures `connectSrc` for its upload page via route-level CSP — no global `connectSrc` needed. Add `imgSrc` if you display S3-hosted images on CMS pages (previews on edit/detail views).
 
 ## Configuration Options
 

--- a/packages/plugins/s3-storage/mod.ts
+++ b/packages/plugins/s3-storage/mod.ts
@@ -571,6 +571,7 @@ export function createS3StoragePlugin(
       {
         pattern: ':table/:id/:column',
         methods: ['GET'],
+        csp: { connectSrc: [options.publicEndpoint] },
         handler: (ctx) => {
           const { table, id, column } = ctx.params;
 

--- a/packages/ui/deno.json
+++ b/packages/ui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/ui",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": "./mod.ts",
   "publish": {
     "include": [

--- a/packages/workers/deno.json
+++ b/packages/workers/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotsauce/workers",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "exports": "./mod.ts",
   "publish": {
     "include": [

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -404,15 +404,16 @@ export interface PluginRoute {
   render?: string;
 
   /**
-   * Route-specific CSP overrides.
-   * Merged with the global CSP at startup — only this route gets the extra sources.
+   * Route-specific CSP extensions.
+   * Concatenated with the global CSP at startup — route sources are appended
+   * to the global directive arrays, so both global and route values apply.
    *
    * @example csp: { styleSrc: ["'unsafe-inline'"] }
    */
   csp?: {
-    /** Additional sources for style-src (e.g., "'unsafe-inline'" for runtime styles) */
+    /** Additional sources appended to style-src (e.g., "'unsafe-inline'" for runtime styles) */
     styleSrc?: string[];
-    /** Additional origins for connect-src (e.g., S3 endpoint for direct uploads) */
+    /** Additional origins appended to connect-src (e.g., S3 endpoint for direct uploads) */
     connectSrc?: string[];
   };
 }

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -402,4 +402,15 @@ export interface PluginRoute {
    * @example 'renderEditor' → Worker receives { type: 'renderEditor', id, context }
    */
   render?: string;
+
+  /**
+   * Route-specific CSP overrides.
+   * Merged with the global CSP at startup — only this route gets the extra sources.
+   *
+   * @example csp: { styleSrc: ["'unsafe-inline'"] }
+   */
+  csp?: {
+    /** Additional sources for style-src (e.g., "'unsafe-inline'" for runtime styles) */
+    styleSrc?: string[];
+  };
 }

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -412,5 +412,7 @@ export interface PluginRoute {
   csp?: {
     /** Additional sources for style-src (e.g., "'unsafe-inline'" for runtime styles) */
     styleSrc?: string[];
+    /** Additional origins for connect-src (e.g., S3 endpoint for direct uploads) */
+    connectSrc?: string[];
   };
 }


### PR DESCRIPTION
## Summary

Adds `styleSrc` to `CspOptions` and introduces route-level CSP overrides on `PluginRoute`. This fixes CSP violations from Puck/React runtime inline `style` attributes without relaxing CSP globally.

## Problem

Puck/React sets `style=""` attributes on DOM elements at runtime (drag handles, overlays, positioning), causing `style-src` CSP violations. We need `'unsafe-inline'` for `style-src` — but only on the editor route, not everywhere.

## Solution

### `styleSrc` on `CspOptions`

- New optional `styleSrc` directive accepts CSP keywords (`'unsafe-inline'`, `'unsafe-hashes'`), hash/nonce sources, and URL origins
- `'unsafe-eval'` is explicitly blocked
- Integrators can set it globally if needed: `csp: { styleSrc: ["'unsafe-inline'"] }`

### Route-level CSP on `PluginRoute`

- New optional `csp` field on `PluginRoute`: `csp: { styleSrc: ["'unsafe-inline'"] }`
- Route CSP is **merged** with the global CSP at startup — only the specific route gets extra sources
- Pre-computed once at startup (zero per-request overhead)
- Routes without `csp` use the global security headers as before

### Puck plugin

- Editor route (`/:table/:id/:column`) declares `csp: { styleSrc: ["'unsafe-inline'"] }`
- Asset routes remain strict — no CSP relaxation

## Changes

| File | Change |
|------|--------|
| `packages/cms/types.ts` | `styleSrc` on `CspOptions`, `routeSecurityHeaders` on `ResolvedCmsOptions` |
| `packages/cms/http.ts` | `buildSecurityHeaders()` handles `styleSrc` in `style-src` directive |
| `packages/cms/validation.ts` | CSP keyword validation (`'unsafe-inline'`, hashes, nonces; blocks `'unsafe-eval'`) |
| `packages/workers/types.ts` | `csp?: { styleSrc?: string[] }` on `PluginRoute` |
| `packages/cms/mod.ts` | Pre-compute route-specific headers at startup, use in `handlePluginRoute()` |
| `packages/plugins/puck/mod.ts` | Editor route declares `csp: { styleSrc: ["'unsafe-inline'"] }` |
| Tests | `styleSrc` in `buildSecurityHeaders`, CSP keyword validation, route-level CSP merge |
| Docs | `CspOptions` table, CSP section, SECURITY.md, Puck README |
| `README.md` | Future feature: plugin permission approval |

## Future work

Plugin permission approval system (env var hash or DB table) to gate plugin CSP/capability changes — tracked in Features list.
