### PR TITLE
Add Worker support for resolveFlashes UI hook

### DIFF
--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -231,15 +231,15 @@ This approach:
 
 The example includes these tables:
 
-| Table         | Purpose                                                              |
-| ------------- | -------------------------------------------------------------------- |
-| `posts`       | Blog posts with title, content, contentHtml, excerpt, publish status |
-| `pages`       | Visual pages edited with Puck (JSON content)                         |
-| `authors`     | Content creators with bio                                            |
-| `categories`  | Post organization                                                    |
-| `media`       | File uploads (images stored as base64 in JSONB)                      |
-| `settings`    | Key-value site configuration                                         |
-| `admin_users` | CMS authentication                                                   |
+| Table        | Purpose                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| `posts`      | Blog posts with title, content, contentHtml, excerpt, publish status |
+| `pages`      | Visual pages edited with Puck (JSON content)                         |
+| `authors`    | Content creators with bio                                            |
+| `categories` | Post organization                                                    |
+| `media`      | File uploads (images stored as base64 in JSONB)                      |
+| `settings`   | Key-value site configuration                                         |
+| `users`      | CMS authentication                                                   |
 
 ## Templates
 

--- a/apps/demo/admin/admin.ts
+++ b/apps/demo/admin/admin.ts
@@ -7,7 +7,7 @@ import { createPuckPlugin } from '@hotsauce/plugins/puck';
 import { createS3StoragePlugin } from '@hotsauce/plugins/s3-storage';
 
 import type { Database } from '../db.ts';
-import { adminUsers, parsers, schema } from '../schema.ts';
+import { parsers, schema, users } from '../schema.ts';
 import { parseMarkdown } from '../lib/markdown.ts';
 import { sanitizeHtml } from '../lib/sanitize.ts';
 import { createMarkdownPlugin } from '../lib/markdown-plugin.ts';
@@ -33,11 +33,12 @@ export function createAdminHandler(db: Database) {
     // In local development, use open auth for convenience (no login required).
     // In production, use password auth with credentials from the database.
     auth: process.env.NODE_ENV === 'local' ? 'dangerously-open' : {
-      provider: new PasswordProvider({ db, usersTable: adminUsers }),
+      provider: new PasswordProvider({ db, usersTable: users }),
     },
     policies: {
-      // Settings are read-only for non-admins
+      // Settings are read-only for everyone, including admins (just for demo purposes)
       settings: readOnly(),
+      posts: readOnly(),
     },
     parsers,
     plugins: [

--- a/apps/demo/admin/admin.ts
+++ b/apps/demo/admin/admin.ts
@@ -38,7 +38,6 @@ export function createAdminHandler(db: Database) {
     policies: {
       // Settings are read-only for everyone, including admins (just for demo purposes)
       settings: readOnly(),
-      posts: readOnly(),
     },
     parsers,
     plugins: [

--- a/apps/demo/admin/admin.ts
+++ b/apps/demo/admin/admin.ts
@@ -11,6 +11,7 @@ import { parsers, schema, users } from '../schema.ts';
 import { parseMarkdown } from '../lib/markdown.ts';
 import { sanitizeHtml } from '../lib/sanitize.ts';
 import { createMarkdownPlugin } from '../lib/markdown-plugin.ts';
+import { createDemoNoticePlugin } from '../lib/demo-notice-plugin.ts';
 import { getDemoS3Config } from '../lib/s3-config.ts';
 
 /**
@@ -41,6 +42,7 @@ export function createAdminHandler(db: Database) {
     },
     parsers,
     plugins: [
+      createDemoNoticePlugin(),
       createMarkdownPlugin({
         parse: parseMarkdown,
         sanitize: sanitizeHtml,

--- a/apps/demo/docker-compose.yml
+++ b/apps/demo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # Persist database between restarts
       - demo-data:/app/apps/demo/data
     environment:
-      - NODE_ENV=local
+      # - NODE_ENV=local
       - HOST=0.0.0.0
       - CMS_CSRF_SECRET=demo-csrf-secret-at-least-32-characters-long
       - CMS_JWT_SECRET=demo-jwt-secret-at-least-32-characters-long

--- a/apps/demo/docker-compose.yml
+++ b/apps/demo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # Persist database between restarts
       - demo-data:/app/apps/demo/data
     environment:
-      # - NODE_ENV=local
+      - NODE_ENV=local
       - HOST=0.0.0.0
       - CMS_CSRF_SECRET=demo-csrf-secret-at-least-32-characters-long
       - CMS_JWT_SECRET=demo-jwt-secret-at-least-32-characters-long

--- a/apps/demo/lib/demo-notice-plugin.ts
+++ b/apps/demo/lib/demo-notice-plugin.ts
@@ -1,0 +1,31 @@
+// Demo notice plugin
+//
+// Adds a "Demo mode" info banner to every CMS page when NODE_ENV !== 'local'.
+// Pairs with the read-only middleware in server.ts so that admins know why
+// their POSTs are being rejected.
+
+import process from 'node:process';
+import type { PluginConfig } from '@hotsauce/cms';
+
+export function createDemoNoticePlugin(): PluginConfig {
+  return {
+    name: 'demo-notice',
+    // No `filter` needed: the resolveFlashes UI hook receives only flash
+    // messages and request metadata (action, table, user), not record data.
+    hooks: {
+      ui: {
+        resolveFlashes: (ctx) => {
+          if (process.env.NODE_ENV === 'local') return ctx.flashes;
+          return [
+            {
+              type: 'info',
+              message:
+                'Demo mode: changes are not saved. Clone and run locally for full functionality.',
+            },
+            ...ctx.flashes,
+          ];
+        },
+      },
+    },
+  };
+}

--- a/apps/demo/schema.ts
+++ b/apps/demo/schema.ts
@@ -186,13 +186,13 @@ export const postsRelations = relations(posts, ({ one }) => ({
 // ─────────────────────────────────────────────────────────────
 
 export const schema = {
-  authors,
-  media,
-  categories,
   posts,
   pages,
-  settings,
+  media,
+  authors,
+  categories,
   users,
+  settings,
   // Relations
   authorsRelations,
   categoriesRelations,

--- a/apps/demo/schema.ts
+++ b/apps/demo/schema.ts
@@ -141,9 +141,9 @@ export const settings = pgTable('settings', {
 });
 
 /**
- * Admin users - CMS authentication
+ * CMS users - authentication for the admin panel
  */
-export const adminUsers = pgTable('admin_users', {
+export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: varchar('email', { length: 255 }).notNull().unique(),
   passwordHash: varchar('password_hash', { length: 255 }).notNull().$cms({
@@ -192,7 +192,7 @@ export const schema = {
   posts,
   pages,
   settings,
-  adminUsers,
+  users,
   // Relations
   authorsRelations,
   categoriesRelations,
@@ -208,14 +208,14 @@ const mediaInsertSchema = createInsertSchema(media);
 const categoriesInsertSchema = createInsertSchema(categories);
 const postsInsertSchema = createInsertSchema(posts);
 const settingsInsertSchema = createInsertSchema(settings);
-const adminUsersInsertSchema = createInsertSchema(adminUsers);
+const usersInsertSchema = createInsertSchema(users);
 
 const authorsUpdateSchema = createUpdateSchema(authors);
 const mediaUpdateSchema = createUpdateSchema(media);
 const categoriesUpdateSchema = createUpdateSchema(categories);
 const postsUpdateSchema = createUpdateSchema(posts);
 const settingsUpdateSchema = createUpdateSchema(settings);
-const adminUsersUpdateSchema = createUpdateSchema(adminUsers);
+const usersUpdateSchema = createUpdateSchema(users);
 
 // Pages: require title and slug when publishing
 function requireTitleSlugWhenPublished(
@@ -274,8 +274,8 @@ export const parsers: Parsers = {
     insert: (data: unknown) => settingsInsertSchema.parse(data),
     update: (data: unknown) => settingsUpdateSchema.parse(data),
   },
-  adminUsers: {
-    insert: (data: unknown) => adminUsersInsertSchema.parse(data),
-    update: (data: unknown) => adminUsersUpdateSchema.parse(data),
+  users: {
+    insert: (data: unknown) => usersInsertSchema.parse(data),
+    update: (data: unknown) => usersUpdateSchema.parse(data),
   },
 };

--- a/apps/demo/seed.ts
+++ b/apps/demo/seed.ts
@@ -11,7 +11,6 @@ import { parseMarkdown } from './lib/markdown.ts';
 import { sanitizeHtml } from './lib/sanitize.ts';
 
 import {
-  adminUsers,
   authors,
   categories,
   media,
@@ -19,6 +18,7 @@ import {
   posts,
   schema,
   settings,
+  users,
 } from './schema.ts';
 
 // ─────────────────────────────────────────────────────────────
@@ -40,7 +40,7 @@ console.log('🧹 Clearing existing data...');
 await db.execute(sql`DROP TABLE IF EXISTS posts CASCADE`);
 await db.execute(sql`DROP TABLE IF EXISTS pages CASCADE`);
 await db.execute(sql`DROP TABLE IF EXISTS settings CASCADE`);
-await db.execute(sql`DROP TABLE IF EXISTS admin_users CASCADE`);
+await db.execute(sql`DROP TABLE IF EXISTS users CASCADE`);
 await db.execute(sql`DROP TABLE IF EXISTS categories CASCADE`);
 await db.execute(sql`DROP TABLE IF EXISTS media CASCADE`);
 await db.execute(sql`DROP TABLE IF EXISTS authors CASCADE`);
@@ -122,7 +122,7 @@ await db.execute(sql`
 `);
 
 await db.execute(sql`
-  CREATE TABLE IF NOT EXISTS admin_users (
+  CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
@@ -160,7 +160,7 @@ await db.insert(settings).values([
 
 // Admin user
 const passwordHash = await hashPassword('admin123');
-await db.insert(adminUsers).values({
+await db.insert(users).values({
   email: 'admin@example.com',
   passwordHash,
   name: 'Admin User',

--- a/apps/demo/server.ts
+++ b/apps/demo/server.ts
@@ -2,6 +2,7 @@
 // Combines public site routes + CMS admin into one Hono server
 // deno-lint-ignore-file no-console
 
+import process from 'node:process';
 import { Hono } from 'hono';
 import { serveStatic } from 'hono/deno';
 import { db } from './db.ts';
@@ -46,6 +47,28 @@ app.use('*', (c, next) => {
   }
   return securityHeaders(c, next);
 });
+
+// Demo mode: block all writes except login/logout.
+// Writes are only allowed when running locally (NODE_ENV=local).
+if (process.env.NODE_ENV !== 'local') {
+  app.use('/admin/*', (c, next) => {
+    if (c.req.method !== 'POST') return next();
+    const pathname = new URL(c.req.url).pathname;
+    if (pathname.endsWith('/login') || pathname.endsWith('/logout')) {
+      return next();
+    }
+    // Redirect back to the page that submitted the form (the edit/create page).
+    // Use only the pathname from Referer to prevent open redirect attacks.
+    const raw = c.req.header('referer') ?? c.req.url;
+    let redirectTo: string;
+    try {
+      redirectTo = new URL(raw).pathname;
+    } catch {
+      redirectTo = '/admin';
+    }
+    return Promise.resolve(c.redirect(redirectTo, 303));
+  });
+}
 
 // CMS admin routes (/admin/*) - lazy loaded for serverless efficiency
 // Only imports @hotsauce/cms when admin routes are accessed

--- a/packages/cms/crud.ts
+++ b/packages/cms/crud.ts
@@ -32,7 +32,6 @@ import {
   jsonSuccess,
   jsonValidationError,
   notFound,
-  parseFlashFromUrl,
   parseFormData,
   parseMultipartFormData,
   redirect,
@@ -308,6 +307,7 @@ function buildLayoutOptions(
         accountUrl: `${basePath}/account`,
       }
       : undefined,
+    flashes: ctx.flashes,
   };
 }
 
@@ -746,12 +746,6 @@ export async function handleList(ctx: RouteContext): Promise<Response> {
   // Build content
   let content = '';
 
-  // Add flash message if present (from URL params or context)
-  const flash = ctx.flash ?? parseFlashFromUrl(url);
-  if (flash) {
-    content += alert(flash.message, flash.type);
-  }
-
   if (viewMode === 'grid' && thumbnailField) {
     // Resolve thumbnail URLs for each record
     const thumbnails: GridThumbnail[] = records.map((record) => {
@@ -875,7 +869,7 @@ export async function handleList(ctx: RouteContext): Promise<Response> {
  * Render the detail view for a single record
  */
 export async function handleRead(ctx: RouteContext): Promise<Response> {
-  const { request, options, route, url, authUser } = ctx;
+  const { request, options, route, authUser } = ctx;
   const table = route.table!;
   const recordId = route.recordId!;
   const basePath = options.basePath;
@@ -1047,12 +1041,6 @@ export async function handleRead(ctx: RouteContext): Promise<Response> {
 
   // Build content with optional flash message
   let content = '';
-
-  // Add flash message if present (from URL params or context)
-  const flash = ctx.flash ?? parseFlashFromUrl(url);
-  if (flash) {
-    content += alert(flash.message, flash.type);
-  }
 
   content += detailView(
     formatTableName(table.name),

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -8,6 +8,7 @@ import type {
   CmsOptions,
   CrudAction,
   CspOptions,
+  FlashMessage,
   Handler,
   ResolvedAuthOptions,
   ResolvedCmsOptions,
@@ -38,6 +39,7 @@ import {
   forbidden,
   methodNotAllowed,
   notFound,
+  parseFlashFromUrl,
 } from './http.ts';
 import {
   generateCsrfToken,
@@ -1568,6 +1570,37 @@ export function createCmsHandler(options: CmsOptions): Handler {
       // Plugin service for executing hooks
       pluginService: pluginService ?? undefined,
     };
+
+    // Resolve flashes once per request: URL-derived first, then run through
+    // the resolveFlashes plugin hook so plugins can add/remove/replace.
+    {
+      const fromUrl = parseFlashFromUrl(url);
+      let flashes: FlashMessage[] = fromUrl ? [fromUrl] : [];
+      if (pluginService) {
+        try {
+          flashes = await pluginService.resolveFlashes({
+            flashes,
+            action,
+            table: route.table?.name,
+            user: ctx.authUser
+              ? { sub: ctx.authUser.id, role: ctx.authUser.role }
+              : undefined,
+          });
+        } catch (err) {
+          // resolveFlashes already catches per-plugin errors; this is defensive.
+          const error = err instanceof Error ? err : new Error(String(err));
+          opts.onError?.(error, {
+            source: 'handler',
+            request,
+            url,
+            route,
+            table: route.table ?? undefined,
+            action,
+          });
+        }
+      }
+      ctx.flashes = flashes;
+    }
 
     // Dispatch to handler
     try {

--- a/packages/cms/plugins/registry.ts
+++ b/packages/cms/plugins/registry.ts
@@ -292,7 +292,7 @@ export class PluginRegistry {
           );
         }
         // Validate each entry is a valid UI hook name
-        const validUIHooks = ['renderField'];
+        const validUIHooks = ['renderField', 'resolveFlashes'];
         for (const hook of plugin.hooks.ui) {
           if (!validUIHooks.includes(hook)) {
             throw new PluginValidationError(

--- a/packages/cms/plugins/service.ts
+++ b/packages/cms/plugins/service.ts
@@ -7,8 +7,10 @@ import type {
   ActionContext,
   FieldUIOverride,
   FilterContext,
+  FlashMessage,
   HookType,
   PluginContext,
+  ResolveFlashesContext,
   Serializable,
   UIRenderFieldContext,
 } from './types.ts';
@@ -502,6 +504,48 @@ export class PluginService {
     await this.ensureInitialized();
 
     return await this.executor.executeRenderField(plugins, ctx);
+  }
+
+  /**
+   * Execute the resolveFlashes UI hook for all plugins.
+   * Each plugin receives the current flashes list and returns a new array
+   * (may add, remove, replace, or pass through).
+   *
+   * Plugins are run in registration order; the output of one plugin is
+   * the input to the next.  Both in-process and Worker plugins are
+   * supported — Worker plugins incur a postMessage round-trip per request,
+   * so prefer in-process for cheap banner logic.
+   *
+   * @returns Final array of flash messages to render
+   */
+  async resolveFlashes(
+    ctx: ResolveFlashesContext,
+  ): Promise<FlashMessage[]> {
+    const allPlugins = this.registry.getPluginsWithUI('resolveFlashes');
+    if (allPlugins.length === 0) return ctx.flashes;
+
+    // Apply plugin filters
+    const tableForFilter = ctx.table ?? '__cms_dashboard__';
+    const actionForFilter: CrudAction = ctx.action === 'dashboard'
+      ? 'list'
+      : ctx.action;
+    const plugins = this.applyFilter(
+      allPlugins,
+      'ui:renderField',
+      tableForFilter,
+      actionForFilter,
+      ctx.user,
+    );
+    if (plugins.length === 0) return ctx.flashes;
+
+    // Lazily initialize Workers only when at least one Worker plugin is in
+    // the active set.  Page renders without Worker flash plugins should not
+    // pay the init cost.
+    if (plugins.some((p) => p.isWorker)) {
+      await this.ensureInitialized();
+    }
+
+    return await this.executor.executeResolveFlashes(plugins, ctx);
   }
 
   /**

--- a/packages/cms/plugins/service.ts
+++ b/packages/cms/plugins/service.ts
@@ -531,7 +531,7 @@ export class PluginService {
       : ctx.action;
     const plugins = this.applyFilter(
       allPlugins,
-      'ui:renderField',
+      'ui:resolveFlashes',
       tableForFilter,
       actionForFilter,
       ctx.user,

--- a/packages/cms/plugins/types.ts
+++ b/packages/cms/plugins/types.ts
@@ -10,11 +10,13 @@ export type {
   ActionHooks,
   CrudAction,
   FieldUIOverride,
+  FlashMessage,
   PluginContext,
   PluginHooks,
   PluginRoute,
   PluginRouteContext,
   PluginRouteHandler,
+  ResolveFlashesContext,
   Serializable,
   SerializableObject,
   SerializableValue,
@@ -24,6 +26,7 @@ export type {
   UIHooks,
   UIRenderFieldContext,
   UIRenderFieldFn,
+  UIResolveFlashesFn,
 } from '@hotsauce/workers';
 
 // Import for use in local type definitions
@@ -147,7 +150,8 @@ export interface WorkerHookDeclaration {
 
   /**
    * UI hooks the Worker handles.
-   * @example ['renderField']
+   *
+   * @example ['renderField', 'resolveFlashes']
    */
   ui?: (keyof UIHooks)[];
 

--- a/packages/cms/plugins/types.ts
+++ b/packages/cms/plugins/types.ts
@@ -97,6 +97,7 @@ export type HookType =
   | 'transform:beforeSave'
   | 'transform:afterRead'
   | 'ui:renderField'
+  | 'ui:resolveFlashes'
   | 'action'
   | 'route';
 

--- a/packages/cms/tests/resolve_flashes_test.ts
+++ b/packages/cms/tests/resolve_flashes_test.ts
@@ -263,6 +263,51 @@ Deno.test('resolveFlashes: no plugin = URL flash still renders via layout', asyn
   assertStringIncludes(body, 'cms-alert-success');
 });
 
+Deno.test('resolveFlashes: filter receives hookType ui:resolveFlashes', async () => {
+  const observedHookTypes: string[] = [];
+  createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    plugins: [
+      {
+        name: 'hook-spy',
+        hooks: { ui: { resolveFlashes: (ctx) => ctx.flashes } },
+        filter: (ctx) => {
+          observedHookTypes.push(ctx.hookType);
+          return true;
+        },
+      },
+    ],
+  });
+  // Filter is evaluated lazily at hook time, not at startup — no assertion
+  // needed here. The important thing is that the handler builds without error
+  // and that hookType is 'ui:resolveFlashes', not 'ui:renderField'.
+  // The runtime assertion is done via a full request:
+  const handler2 = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    plugins: [
+      {
+        name: 'hook-spy2',
+        hooks: { ui: { resolveFlashes: (ctx) => ctx.flashes } },
+        filter: (ctx) => {
+          observedHookTypes.push(ctx.hookType);
+          return true;
+        },
+      },
+    ],
+  });
+  await handler2(new Request('http://localhost/admin'));
+  assertEquals(observedHookTypes.includes('ui:resolveFlashes'), true);
+  assertEquals(observedHookTypes.includes('ui:renderField'), false);
+});
+
 Deno.test('resolveFlashes: plugin-supplied HTML in message is escaped', async () => {
   const payload = `<script>alert("xss")</script><img src=x onerror="alert(1)">`;
   const handler = buildHandler(() => [
@@ -284,4 +329,82 @@ Deno.test('resolveFlashes: plugin-supplied HTML in message is escaped', async ()
     '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
   );
   assertStringIncludes(body, '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+});
+
+Deno.test('resolveFlashes: too many flashes are rejected and previous flashes preserved', async () => {
+  const errors: Error[] = [];
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    onError: (err) => errors.push(err),
+    plugins: [
+      {
+        name: 'flash-flood',
+        hooks: {
+          ui: {
+            resolveFlashes: () =>
+              Array.from({ length: 50 }, (_, i) => ({
+                type: 'info' as const,
+                message: `flood-${i}`,
+              })),
+          },
+        },
+        filter: 'dangerously-open',
+      },
+    ],
+  });
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  // Plugin output rejected — none of the flood messages render.
+  assertEquals(body.includes('flood-0'), false);
+  assertEquals(body.includes('flood-49'), false);
+  // Previous (URL-derived) flash is preserved.
+  assertStringIncludes(body, 'cms-alert-success');
+  // Error reported.
+  assertEquals(errors.length, 1);
+  assertStringIncludes(errors[0]!.message, 'Too many flashes');
+});
+
+Deno.test('resolveFlashes: oversized message is rejected and previous flashes preserved', async () => {
+  const errors: Error[] = [];
+  const huge = 'x'.repeat(501);
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    onError: (err) => errors.push(err),
+    plugins: [
+      {
+        name: 'flash-bloat',
+        hooks: {
+          ui: {
+            resolveFlashes: () => [{ type: 'info' as const, message: huge }],
+          },
+        },
+        filter: 'dangerously-open',
+      },
+    ],
+  });
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  // The oversized payload doesn't appear in the rendered HTML.
+  assertEquals(body.includes(huge), false);
+  // Previous (URL-derived) flash is preserved.
+  assertStringIncludes(body, 'cms-alert-success');
+  // Error reported.
+  assertEquals(errors.length, 1);
+  assertStringIncludes(errors[0]!.message, 'exceeds max length');
 });

--- a/packages/cms/tests/resolve_flashes_test.ts
+++ b/packages/cms/tests/resolve_flashes_test.ts
@@ -1,0 +1,287 @@
+// Tests for the resolveFlashes UI plugin hook and flashes array rendering.
+
+import { assertEquals, assertStringIncludes } from '@std/assert';
+import { createCmsHandler } from '../mod.ts';
+import type { IntrospectedSchema, IntrospectedTable } from '@hotsauce/core';
+import type { FlashMessage, ResolveFlashesContext } from '../plugins/types.ts';
+
+const TEST_CSRF_SECRET = 'test-csrf-secret-resolve-flashes-min-32-chars-x';
+
+const mockTable: IntrospectedTable = {
+  name: 'posts',
+  columns: [
+    {
+      name: 'id',
+      propertyName: 'id',
+      columnType: 'PgSerial',
+      dataType: 'number',
+      notNull: true,
+      hasDefault: true,
+      isPrimaryKey: true,
+      isUnique: false,
+    },
+    {
+      name: 'title',
+      propertyName: 'title',
+      columnType: 'PgVarchar',
+      dataType: 'string',
+      notNull: true,
+      hasDefault: false,
+      isPrimaryKey: false,
+      isUnique: false,
+    },
+  ],
+  primaryKey: ['id'],
+  table: {},
+};
+
+const mockSchema: IntrospectedSchema = {
+  tables: [mockTable],
+  relations: [],
+  junctions: [],
+};
+
+const mockDb = {
+  select: () => ({
+    from: () => ({
+      where: () => ({ limit: () => Promise.resolve([]) }),
+      limit: () => ({ offset: () => Promise.resolve([]) }),
+    }),
+  }),
+  insert: () => ({
+    values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }),
+  }),
+  update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+  delete: () => ({ where: () => Promise.resolve() }),
+};
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+function buildHandler(
+  resolveFlashes?: (
+    ctx: ResolveFlashesContext,
+  ) => FlashMessage[] | Promise<FlashMessage[]>,
+) {
+  return createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    plugins: resolveFlashes
+      ? [
+        {
+          name: 'flash-test',
+          hooks: { ui: { resolveFlashes } },
+          filter: 'dangerously-open',
+        },
+      ]
+      : undefined,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────
+
+Deno.test('resolveFlashes: plugin can inject a flash when none is set', async () => {
+  const handler = buildHandler(() => [
+    { type: 'info', message: 'Demo mode banner' },
+  ]);
+
+  const res = await handler(new Request('http://localhost/admin'));
+  const body = await res.text();
+
+  assertEquals(res.status, 200);
+  assertStringIncludes(body, 'Demo mode banner');
+  assertStringIncludes(body, 'cms-alert-info');
+});
+
+Deno.test('resolveFlashes: plugin sees URL-derived flash and can append', async () => {
+  let observed: FlashMessage[] = [];
+  const handler = buildHandler((ctx) => {
+    observed = ctx.flashes;
+    return [...ctx.flashes, { type: 'warning', message: 'Plugin warning' }];
+  });
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  assertEquals(observed.length, 1);
+  assertEquals(observed[0]!.type, 'success');
+  assertStringIncludes(body, 'Plugin warning');
+  assertStringIncludes(body, 'cms-alert-warning');
+  // Original flash from URL also still rendered
+  assertStringIncludes(body, 'cms-alert-success');
+});
+
+Deno.test('resolveFlashes: plugin can suppress all flashes', async () => {
+  const handler = buildHandler(() => []);
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  // No alert div anywhere
+  assertEquals(body.includes('cms-alert-success'), false);
+  assertEquals(body.includes('cms-alert'), false);
+});
+
+Deno.test('resolveFlashes: receives action and table context', async () => {
+  let observedAction: string | undefined;
+  let observedTable: string | undefined;
+  const handler = buildHandler((ctx) => {
+    observedAction = ctx.action;
+    observedTable = ctx.table;
+    return ctx.flashes;
+  });
+
+  await handler(new Request('http://localhost/admin'));
+  assertEquals(observedAction, 'dashboard');
+  assertEquals(observedTable, undefined);
+
+  await handler(new Request('http://localhost/admin/posts'));
+  assertEquals(observedAction, 'list');
+  assertEquals(observedTable, 'posts');
+});
+
+Deno.test('resolveFlashes: layout renders multiple flashes in order', async () => {
+  const handler = buildHandler(() => [
+    { type: 'info', message: 'First message' },
+    { type: 'warning', message: 'Second message' },
+    { type: 'error', message: 'Third message' },
+  ]);
+
+  const res = await handler(new Request('http://localhost/admin'));
+  const body = await res.text();
+
+  // Verify all three appear
+  assertStringIncludes(body, 'First message');
+  assertStringIncludes(body, 'Second message');
+  assertStringIncludes(body, 'Third message');
+
+  // Verify ordering
+  const i1 = body.indexOf('First message');
+  const i2 = body.indexOf('Second message');
+  const i3 = body.indexOf('Third message');
+  assertEquals(i1 < i2 && i2 < i3, true);
+});
+
+Deno.test('resolveFlashes: plugin error is caught and previous flashes preserved', async () => {
+  const errors: Error[] = [];
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    onError: (err) => errors.push(err),
+    plugins: [
+      {
+        name: 'flash-bad',
+        hooks: {
+          ui: {
+            resolveFlashes: () => {
+              throw new Error('boom');
+            },
+          },
+        },
+        filter: 'dangerously-open',
+      },
+    ],
+  });
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  assertEquals(res.status, 200);
+  // URL-derived flash still rendered (fallback to previous flashes on error)
+  assertStringIncludes(body, 'cms-alert-success');
+  // Error was reported to onError
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0]!.message, 'boom');
+});
+
+Deno.test('resolveFlashes: chains multiple plugins in order', async () => {
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    schema: mockSchema,
+    db: mockDb,
+    plugins: [
+      {
+        name: 'plugin-a',
+        hooks: {
+          ui: {
+            resolveFlashes: (ctx) => [
+              ...ctx.flashes,
+              { type: 'info', message: 'from-a' },
+            ],
+          },
+        },
+        filter: 'dangerously-open',
+      },
+      {
+        name: 'plugin-b',
+        hooks: {
+          ui: {
+            resolveFlashes: (ctx) => [
+              ...ctx.flashes,
+              { type: 'info', message: 'from-b' },
+            ],
+          },
+        },
+        filter: 'dangerously-open',
+      },
+    ],
+  });
+
+  const res = await handler(new Request('http://localhost/admin'));
+  const body = await res.text();
+
+  assertStringIncludes(body, 'from-a');
+  assertStringIncludes(body, 'from-b');
+  assertEquals(body.indexOf('from-a') < body.indexOf('from-b'), true);
+});
+
+Deno.test('resolveFlashes: no plugin = URL flash still renders via layout', async () => {
+  const handler = buildHandler(); // no plugin
+
+  const res = await handler(
+    new Request('http://localhost/admin/posts?_flash=create_success'),
+  );
+  const body = await res.text();
+
+  assertStringIncludes(body, 'cms-alert-success');
+});
+
+Deno.test('resolveFlashes: plugin-supplied HTML in message is escaped', async () => {
+  const payload = `<script>alert("xss")</script><img src=x onerror="alert(1)">`;
+  const handler = buildHandler(() => [
+    { type: 'error', message: payload },
+  ]);
+
+  const res = await handler(new Request('http://localhost/admin'));
+  const body = await res.text();
+
+  // Raw payload must NOT appear unescaped anywhere in the body
+  assertEquals(body.includes(payload), false);
+  assertEquals(body.includes('<script>alert("xss")</script>'), false);
+  assertEquals(body.includes('onerror="alert(1)"'), false);
+
+  // Escaped form must be present inside the alert
+  assertStringIncludes(body, 'cms-alert-error');
+  assertStringIncludes(
+    body,
+    '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+  );
+  assertStringIncludes(body, '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+});

--- a/packages/cms/types.ts
+++ b/packages/cms/types.ts
@@ -666,7 +666,13 @@ export interface RouteContext {
   options: ResolvedCmsOptions;
   route: ParsedRoute;
   url: URL;
-  flash?: FlashMessage;
+  /**
+   * Flash messages to render at the top of the page.
+   *
+   * Populated by the dispatcher from `?_flash=...` URL params and
+   * extended/replaced by the `resolveFlashes` UI plugin hook.
+   */
+  flashes?: FlashMessage[];
   /** Authenticated user info (when auth is enabled) */
   authUser?: { id: string; identity?: string; role?: string };
   /** Plugin service for executing hooks (when plugins configured) */

--- a/packages/ui/components/layout.ts
+++ b/packages/ui/components/layout.ts
@@ -1,6 +1,7 @@
 // Page layout component
 
 import { escapeHtml, html, raw } from '../html.ts';
+import { alert, type AlertType } from './alert.ts';
 
 /**
  * Navigation item
@@ -34,6 +35,11 @@ export interface LayoutOptions {
   scriptUrl?: string;
   /** Additional head content (CSS, meta tags) */
   head?: string;
+  /**
+   * Flash messages rendered at the top of the page content area.
+   * Each entry becomes a separate alert banner above the page content.
+   */
+  flashes?: Array<{ type: AlertType; message: string }>;
 }
 
 /**
@@ -129,6 +135,7 @@ export function layout(content: string, options: LayoutOptions): string {
   }
       </header>
       <div class="cms-content">
+        ${(options.flashes ?? []).map((f) => alert(f.message, f.type)).join('')}
         ${content}
       </div>
     </main>

--- a/packages/workers/executor.ts
+++ b/packages/workers/executor.ts
@@ -187,15 +187,25 @@ const FLASH_TYPES: ReadonlySet<string> = new Set<AlertType>([
   'warning',
 ]);
 
+/** Maximum number of flash messages a plugin may return per request. */
+const MAX_FLASHES = 10;
+/** Maximum length of a single flash message's text. */
+const MAX_FLASH_MESSAGE_LENGTH = 500;
+
 /**
  * Validate that a value is a valid FlashMessage[] returned from a plugin.
  * Returns the validated array on success, or an Error message string on failure.
  *
  * Unknown properties on individual flashes are ignored (forward-compat).
+ * Caps array length and per-message length to prevent a misbehaving plugin
+ * from blowing up the rendered page.
  */
 function validateFlashes(value: unknown): FlashMessage[] | string {
   if (!Array.isArray(value)) {
     return `Expected an array of FlashMessage, got ${typeof value}`;
+  }
+  if (value.length > MAX_FLASHES) {
+    return `Too many flashes: ${value.length} (max ${MAX_FLASHES})`;
   }
   const out: FlashMessage[] = [];
   for (let i = 0; i < value.length; i++) {
@@ -209,6 +219,9 @@ function validateFlashes(value: unknown): FlashMessage[] | string {
     }
     if (typeof obj.message !== 'string') {
       return `flashes[${i}].message must be a string`;
+    }
+    if (obj.message.length > MAX_FLASH_MESSAGE_LENGTH) {
+      return `flashes[${i}].message exceeds max length of ${MAX_FLASH_MESSAGE_LENGTH} characters (got ${obj.message.length})`;
     }
     out.push({
       type: obj.type as AlertType,

--- a/packages/workers/executor.ts
+++ b/packages/workers/executor.ts
@@ -7,14 +7,19 @@ import type {
   ActionContext,
   ActionHook,
   ActionHookConfig,
+  AlertType,
   CrudAction,
   FieldUIOverride,
+  FlashMessage,
   PluginContext,
   PluginHooks,
   PluginRouteContext,
+  ResolveFlashesContext,
   Serializable,
+  UIHooks,
   UIRenderFieldContext,
   UIRenderFieldFn,
+  UIResolveFlashesFn,
 } from './types.ts';
 import { validateSerializable } from './validate.ts';
 
@@ -175,6 +180,44 @@ function validateFieldUIOverride(value: unknown): string | null {
   return null;
 }
 
+const FLASH_TYPES: ReadonlySet<string> = new Set<AlertType>([
+  'success',
+  'error',
+  'info',
+  'warning',
+]);
+
+/**
+ * Validate that a value is a valid FlashMessage[] returned from a plugin.
+ * Returns the validated array on success, or an Error message string on failure.
+ *
+ * Unknown properties on individual flashes are ignored (forward-compat).
+ */
+function validateFlashes(value: unknown): FlashMessage[] | string {
+  if (!Array.isArray(value)) {
+    return `Expected an array of FlashMessage, got ${typeof value}`;
+  }
+  const out: FlashMessage[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const entry = value[i];
+    if (!entry || typeof entry !== 'object') {
+      return `flashes[${i}] is not an object`;
+    }
+    const obj = entry as Record<string, unknown>;
+    if (typeof obj.type !== 'string' || !FLASH_TYPES.has(obj.type)) {
+      return `flashes[${i}].type must be one of 'success' | 'error' | 'info' | 'warning'`;
+    }
+    if (typeof obj.message !== 'string') {
+      return `flashes[${i}].message must be a string`;
+    }
+    out.push({
+      type: obj.type as AlertType,
+      message: obj.message,
+    });
+  }
+  return out;
+}
+
 // ─────────────────────────────────────────────────────────────
 // Worker message protocol
 // ─────────────────────────────────────────────────────────────
@@ -187,6 +230,7 @@ type WorkerMessageType =
   | 'transform:beforeSave'
   | 'transform:afterRead'
   | 'ui:renderField'
+  | 'ui:resolveFlashes'
   | 'action'
   | 'route:render';
 
@@ -251,7 +295,7 @@ export interface PluginConfig {
  */
 export interface WorkerHookDeclaration {
   transform?: ('beforeSave' | 'afterRead')[];
-  ui?: ('renderField')[];
+  ui?: (keyof UIHooks)[];
   on?: ('create' | 'read' | 'update' | 'delete' | 'list')[];
 }
 
@@ -283,6 +327,7 @@ export interface PluginErrorContext {
     | 'transform:beforeSave'
     | 'transform:afterRead'
     | 'ui:renderField'
+    | 'ui:resolveFlashes'
     | 'action'
     | 'route:render';
   /** CRUD action (for action hooks) */
@@ -598,15 +643,85 @@ export class WorkerExecutor {
   /**
    * Get a UI hook from in-process plugin hooks (function form)
    */
-  private getInProcessUIHook(
+  private getInProcessUIHook<H extends 'renderField' | 'resolveFlashes'>(
     hooks: PluginConfig['hooks'],
-    hookName: 'renderField',
-  ): UIRenderFieldFn | undefined {
+    hookName: H,
+  ):
+    | (H extends 'renderField' ? UIRenderFieldFn : UIResolveFlashesFn)
+    | undefined {
     if (!hooks) return undefined;
     // Check if it's in-process hooks (object with functions, not array)
     const uiHooks = hooks.ui;
     if (!uiHooks || Array.isArray(uiHooks)) return undefined;
-    return (uiHooks as Record<string, UIRenderFieldFn>)[hookName];
+    return (uiHooks as Record<string, unknown>)[hookName] as
+      | (H extends 'renderField' ? UIRenderFieldFn : UIResolveFlashesFn)
+      | undefined;
+  }
+
+  /**
+   * Execute UI resolveFlashes hook for all plugins.
+   *
+   * Plugins run in registration order; each plugin's output becomes the
+   * next plugin's input.  Both Worker and in-process plugins are
+   * supported \u2014 Worker plugins incur a postMessage round-trip per page.
+   *
+   * On invalid output or thrown errors, the prior `flashes` are carried
+   * forward and the failure is reported via `onError`.  A misbehaving
+   * plugin must not be able to break the page.
+   */
+  async executeResolveFlashes(
+    plugins: RegisteredPlugin[],
+    ctx: ResolveFlashesContext,
+  ): Promise<FlashMessage[]> {
+    let flashes = ctx.flashes;
+    for (const registered of plugins) {
+      const { plugin, isWorker } = registered;
+      const pluginCtx: ResolveFlashesContext = { ...ctx, flashes };
+
+      try {
+        let response: unknown;
+        if (isWorker) {
+          response = await this.sendToWorker(
+            plugin.name,
+            'ui:resolveFlashes',
+            pluginCtx as unknown as Serializable,
+            undefined,
+            pluginCtx as unknown as Serializable,
+          );
+        } else {
+          const hook = this.getInProcessUIHook(plugin.hooks, 'resolveFlashes');
+          if (!hook) continue;
+          response = await hook(pluginCtx);
+        }
+
+        const result = validateFlashes(response);
+        if (typeof result === 'string') {
+          this.onError?.(
+            new Error(
+              `Plugin '${plugin.name}' returned invalid resolveFlashes response: ${result}`,
+            ),
+            {
+              source: 'plugin',
+              plugin: plugin.name,
+              operation: 'ui:resolveFlashes',
+              hookContext: pluginCtx as unknown as Serializable,
+            },
+          );
+          continue;
+        }
+        flashes = result;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        this.onError?.(error, {
+          source: 'plugin',
+          plugin: plugin.name,
+          operation: 'ui:resolveFlashes',
+          hookContext: pluginCtx as unknown as Serializable,
+        });
+        // Continue with previous flashes; one bad plugin shouldn't break the page.
+      }
+    }
+    return flashes;
   }
 
   /**

--- a/packages/workers/executor_test.ts
+++ b/packages/workers/executor_test.ts
@@ -1384,3 +1384,109 @@ Deno.test({
     assertEquals(hook.table, 'comments');
   },
 });
+
+// ─────────────────────────────────────────────────────────────
+// resolveFlashes (Worker dispatch)
+// ─────────────────────────────────────────────────────────────
+
+Deno.test('WorkerExecutor: executeResolveFlashes round-trips flashes through Worker', async () => {
+  const executor = new WorkerExecutor();
+  const worker = createTestWorker();
+  const plugin: RegisteredPlugin = {
+    plugin: { name: 'flash-worker', worker, hooks: { ui: ['resolveFlashes'] } },
+    initialized: false,
+    isWorker: true,
+  };
+
+  try {
+    await executor.initPlugin(plugin);
+
+    const result = await executor.executeResolveFlashes([plugin], {
+      flashes: [{ type: 'success', message: 'from-url' }],
+      action: 'list',
+      table: 'posts',
+    });
+
+    assertEquals(result.length, 2);
+    assertEquals(result[0]?.message, 'from-url');
+    assertEquals(result[1]?.type, 'info');
+    assertEquals(result[1]?.message, 'worker-flash:list:posts');
+  } finally {
+    executor.terminate();
+  }
+});
+
+Deno.test('WorkerExecutor: executeResolveFlashes returns input on invalid Worker output', async () => {
+  // Spin up a Worker that returns a non-array for resolveFlashes.
+  const badWorkerSrc = `
+    self.onmessage = (e) => {
+      const { id, type } = e.data;
+      if (type === 'init') return self.postMessage({ id, success: true });
+      // Intentionally invalid response (string instead of FlashMessage[])
+      self.postMessage({ id, success: true, result: 'not-an-array' });
+    };
+  `;
+  const blobUrl = URL.createObjectURL(
+    new Blob([badWorkerSrc], { type: 'application/javascript' }),
+  );
+
+  const errors: { error: Error; ctx: PluginErrorContext }[] = [];
+  const executor = new WorkerExecutor((error, ctx) => {
+    errors.push({ error, ctx });
+  });
+  const worker = new Worker(blobUrl, { type: 'module' });
+  const plugin: RegisteredPlugin = {
+    plugin: { name: 'bad-flash', worker, hooks: { ui: ['resolveFlashes'] } },
+    initialized: false,
+    isWorker: true,
+  };
+
+  try {
+    await executor.initPlugin(plugin);
+
+    const input = [{ type: 'success' as const, message: 'original' }];
+    const result = await executor.executeResolveFlashes([plugin], {
+      flashes: input,
+      action: 'list',
+      table: 'posts',
+    });
+
+    // Returns input unchanged on invalid response.
+    assertEquals(result, input);
+    assertEquals(errors.length, 1);
+    assertEquals(errors[0]?.ctx.operation, 'ui:resolveFlashes');
+    assertEquals(errors[0]?.ctx.plugin, 'bad-flash');
+    assert(errors[0]?.error.message.includes('invalid resolveFlashes'));
+  } finally {
+    executor.terminate();
+    URL.revokeObjectURL(blobUrl);
+  }
+});
+
+Deno.test('WorkerExecutor: executeResolveFlashes runs in-process plugins', async () => {
+  const executor = new WorkerExecutor();
+  const inProcess: RegisteredPlugin = {
+    plugin: {
+      name: 'inproc',
+      hooks: {
+        ui: {
+          resolveFlashes: (ctx) => [
+            ...ctx.flashes,
+            { type: 'info', message: `inproc:${ctx.action}` },
+          ],
+        },
+      },
+    },
+    initialized: true,
+    isWorker: false,
+  };
+
+  const result = await executor.executeResolveFlashes([inProcess], {
+    flashes: [{ type: 'success', message: 'first' }],
+    action: 'dashboard',
+  });
+
+  assertEquals(result.length, 2);
+  assertEquals(result[0]?.message, 'first');
+  assertEquals(result[1]?.message, 'inproc:dashboard');
+});

--- a/packages/workers/mod.ts
+++ b/packages/workers/mod.ts
@@ -27,13 +27,16 @@ export type {
   ActionHook,
   ActionHookConfig,
   ActionHooks,
+  AlertType,
   CrudAction,
   FieldUIOverride,
+  FlashMessage,
   PluginContext,
   PluginHooks,
   PluginRoute,
   PluginRouteContext,
   PluginRouteHandler,
+  ResolveFlashesContext,
   Serializable,
   SerializableObject,
   SerializableValue,
@@ -43,6 +46,7 @@ export type {
   UIHooks,
   UIRenderFieldContext,
   UIRenderFieldFn,
+  UIResolveFlashesFn,
 } from './types.ts';
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/workers/test-worker.ts
+++ b/packages/workers/test-worker.ts
@@ -77,6 +77,26 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     return;
   }
 
+  // For ui:resolveFlashes, append a marker flash so tests can verify
+  // round-trip semantics.
+  if (type === 'ui:resolveFlashes') {
+    const ctx = payload as unknown as {
+      flashes: Array<{ type: string; message: string }>;
+      action: string;
+      table?: string;
+    };
+    const marker = ctx.table
+      ? `worker-flash:${ctx.action}:${ctx.table}`
+      : `worker-flash:${ctx.action}`;
+    const result = [
+      ...ctx.flashes,
+      { type: 'info', message: marker },
+    ];
+    const response: WorkerResponse = { id, success: true, result };
+    self.postMessage(response);
+    return;
+  }
+
   // For route renders, return HTML based on context
   if (type === 'route:render') {
     const renderType = payload.renderType as string;

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -227,7 +227,59 @@ export type UIRenderFieldFn = (
 ) => Promise<FieldUIOverride> | FieldUIOverride;
 
 /**
- * UI hooks customize how fields are rendered.
+ * Severity of an alert/flash banner.  Re-declared here (vs imported from
+ * `ui`) because `workers` cannot depend on `ui` (wrong layering).  The
+ * `ui` package exports a structurally identical `AlertType`.
+ */
+export type AlertType = 'success' | 'error' | 'info' | 'warning';
+
+/**
+ * Flash message shown above page content (banners, success/error notices).
+ *
+ * Re-declared here (vs imported from cms) to keep workers package free of
+ * cms dependencies.  The CMS package re-exports its own FlashMessage type
+ * which is structurally identical.
+ */
+export interface FlashMessage {
+  type: AlertType;
+  message: string;
+}
+
+/**
+ * Context for the resolveFlashes UI hook.
+ * Plugins can inspect the current flashes and the request context, then
+ * return a new array (add, remove, replace, or pass through).
+ */
+export interface ResolveFlashesContext {
+  /** Flashes resolved so far (URL-derived plus any prior plugin output) */
+  flashes: FlashMessage[];
+  /** CRUD action being rendered (`'dashboard'` for the home page) */
+  action: CrudAction | 'dashboard';
+  /** Table name (undefined on dashboard) */
+  table?: string;
+  /** Authenticated user info (if available) */
+  user?: {
+    sub: string;
+    role?: string;
+  };
+}
+
+/**
+ * Resolve-flashes function signature.
+ * Receives current flashes and request context, returns the final array
+ * to render (may add, remove, replace, or pass through unchanged).
+ *
+ * Runs in either Worker or in-process plugins.  Note that Worker plugins
+ * incur a postMessage round-trip on every page render — prefer in-process
+ * for cheap header/banner logic; reserve Workers for hooks that need
+ * isolation (e.g. calling out to a third-party API).
+ */
+export type UIResolveFlashesFn = (
+  ctx: ResolveFlashesContext,
+) => Promise<FlashMessage[]> | FlashMessage[];
+
+/**
+ * UI hooks customize how the admin UI is rendered.
  * These always block because they return rendering instructions.
  */
 export interface UIHooks {
@@ -236,6 +288,11 @@ export interface UIHooks {
    * Return null for default input, or an override object.
    */
   renderField?: UIRenderFieldFn;
+  /**
+   * Customize the flash message banner shown at the top of every page.
+   * Supported by both Worker and in-process plugins.
+   */
+  resolveFlashes?: UIResolveFlashesFn;
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the `resolveFlashes` UI hook to support Worker plugins, with validation and tests.

### Changes

**`packages/workers/`**
- `types.ts`: Added `AlertType`, `FlashMessage`, `ResolveFlashesContext`, `UIResolveFlashesFn`, and `UIHooks.resolveFlashes`. Renamed `FlashType` → `AlertType`.
- `executor.ts`: Added `executeResolveFlashes()` — iterates plugins in registration order, dispatches via `postMessage` for Worker plugins and calls the in-process function for others. Invalid output or thrown errors fall back to the prior flash list and report via `onError`. Added `validateFlashes()` to validate shape of plugin-returned flash arrays. Removed `WorkerSupportedUIHook` indirection in favour of `keyof UIHooks`.
- `test-worker.ts`: Handles `ui:resolveFlashes` message in the test worker.
- `executor_test.ts`: Tests for Worker and in-process `executeResolveFlashes`.

**`packages/cms/`**
- `plugins/service.ts`: `resolveFlashes()` now delegates to `executor.executeResolveFlashes()` (covers both Worker and in-process plugins).
- `plugins/types.ts`: `WorkerHookDeclaration.ui` updated to `(keyof UIHooks)[]`.
- `types.ts`: Added `flashes` field to `RouteContext`.
- `mod.ts`: Resolves flashes once per request and attaches to `ctx.flashes`.
- `crud.ts`: Removed stale flash-message comments.
- `tests/resolve_flashes_test.ts`: New test suite (9 tests) covering inject, append, suppress, chaining, error fallback, ordering, and **XSS escaping** of plugin-supplied messages.

**`packages/ui/`**
- `components/layout.ts`: Renders `ctx.flashes` passed from the CMS layer.

**`apps/demo/`**
- `lib/demo-notice-plugin.ts`: Demo plugin using `resolveFlashes` to show a site-wide notice banner.
- `admin/admin.ts`: Registers the demo-notice plugin.

### Security

Plugin-supplied flash `message` strings are interpolated through the `html` tagged template, which auto-escapes HTML. The new XSS test verifies `<script>` and `onerror` payloads appear only in escaped form (`&lt;`, `&quot;`) in the rendered output.