### PR TITLE
feat(ui): add collapsible mobile sidebar using Popover API

### DIFF
--- a/packages/ui/components/layout.ts
+++ b/packages/ui/components/layout.ts
@@ -110,8 +110,8 @@ export function layout(content: string, options: LayoutOptions): string {
     </aside>
     <main class="cms-main">
       <header class="cms-header">
-        <button class="cms-menu-toggle" popovertarget="cms-nav" aria-label="Menu">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <button type="button" class="cms-menu-toggle" popovertarget="cms-nav" aria-controls="cms-nav" aria-label="Menu">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path d="M3 12h18M3 6h18M3 18h18"/>
           </svg>
         </button>

--- a/packages/ui/components/layout.ts
+++ b/packages/ui/components/layout.ts
@@ -100,7 +100,7 @@ export function layout(content: string, options: LayoutOptions): string {
 </head>
 <body>
   <div class="cms-layout">
-    <aside class="cms-sidebar">
+    <aside id="cms-nav" class="cms-sidebar" popover>
       <div class="cms-sidebar-header">
         <h1 class="cms-sidebar-title">${html`
     ${siteName}
@@ -110,6 +110,11 @@ export function layout(content: string, options: LayoutOptions): string {
     </aside>
     <main class="cms-main">
       <header class="cms-header">
+        <button class="cms-menu-toggle" popovertarget="cms-nav" aria-label="Menu">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M3 12h18M3 6h18M3 18h18"/>
+          </svg>
+        </button>
         <h2>${html`
     ${options.title}
   `}</h2>

--- a/packages/ui/styles.ts
+++ b/packages/ui/styles.ts
@@ -618,4 +618,67 @@ body {
   color: var(--cms-gray-300);
   cursor: not-allowed;
 }
+
+/* Mobile Navigation (Popover API) */
+.cms-menu-toggle {
+  display: none;
+  background: var(--cms-gray-900);
+  color: white;
+  border: none;
+  border-radius: var(--cms-radius);
+  padding: 0.5rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.cms-menu-toggle:hover {
+  background: var(--cms-gray-700);
+}
+
+/* Fallback: sidebar always visible if popover not supported */
+@media (max-width: 768px) {
+  .cms-layout {
+    flex-direction: column;
+  }
+}
+
+/* Popover-enabled mobile navigation */
+@supports selector(:popover-open) {
+  @media (max-width: 768px) {
+    .cms-menu-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .cms-sidebar[popover] {
+      position: fixed;
+      inset: 0 auto 0 0;
+      width: 240px;
+      height: 100%;
+      margin: 0;
+      border: none;
+      padding: 1rem 0;
+    }
+
+    .cms-sidebar::backdrop {
+      background: rgba(0, 0, 0, 0.4);
+    }
+
+    .cms-header {
+      gap: 1rem;
+    }
+  }
+
+  @media (min-width: 769px) {
+    /* On desktop, sidebar is always visible (override popover hidden state) */
+    .cms-sidebar[popover] {
+      display: block;
+      position: static;
+      height: auto;
+      border: none;
+      margin: 0;
+    }
+  }
+}
 `;

--- a/packages/ui/styles.ts
+++ b/packages/ui/styles.ts
@@ -640,6 +640,10 @@ body {
   .cms-layout {
     flex-direction: column;
   }
+
+  .cms-sidebar {
+    width: 100%;
+  }
 }
 
 /* Popover-enabled mobile navigation */
@@ -659,6 +663,8 @@ body {
       margin: 0;
       border: none;
       padding: 1rem 0;
+      overflow-y: auto;
+      overscroll-behavior: contain;
     }
 
     .cms-sidebar::backdrop {
@@ -667,6 +673,11 @@ body {
 
     .cms-header {
       gap: 1rem;
+      justify-content: flex-start;
+    }
+
+    .cms-user {
+      margin-left: auto;
     }
   }
 

--- a/packages/ui/tests/layout_test.ts
+++ b/packages/ui/tests/layout_test.ts
@@ -118,8 +118,11 @@ Deno.test('layout: sidebar has popover attribute and id for mobile navigation', 
   });
 
   // Sidebar should have id="cms-nav" and popover attribute
-  assertStringIncludes(result, 'id="cms-nav"');
-  assertStringIncludes(result, 'popover');
+  // Use specific assertion to avoid matching popovertarget="cms-nav"
+  assertStringIncludes(
+    result,
+    '<aside id="cms-nav" class="cms-sidebar" popover>',
+  );
 });
 
 Deno.test('layout: menu toggle has correct accessibility attributes', () => {
@@ -127,15 +130,12 @@ Deno.test('layout: menu toggle has correct accessibility attributes', () => {
     title: 'Test Page',
   });
 
-  // Toggle button should have:
-  // - type="button" (prevent form submission)
-  // - popovertarget="cms-nav" (control the popover)
-  // - aria-controls="cms-nav" (accessibility association)
-  // - aria-label (accessible name)
-  assertStringIncludes(result, 'type="button"');
-  assertStringIncludes(result, 'popovertarget="cms-nav"');
-  assertStringIncludes(result, 'aria-controls="cms-nav"');
-  assertStringIncludes(result, 'aria-label="Menu"');
+  // Toggle button should have all required attributes
+  // Assert the full button tag to ensure we're testing the correct element
+  assertStringIncludes(
+    result,
+    '<button type="button" class="cms-menu-toggle" popovertarget="cms-nav" aria-controls="cms-nav" aria-label="Menu">',
+  );
   // SVG should be aria-hidden
   assertStringIncludes(result, 'aria-hidden="true"');
 });

--- a/packages/ui/tests/layout_test.ts
+++ b/packages/ui/tests/layout_test.ts
@@ -111,3 +111,31 @@ Deno.test('layout: includes stylesheet link', () => {
     '<link rel="stylesheet" href="/admin/styles.css">',
   );
 });
+
+Deno.test('layout: sidebar has popover attribute and id for mobile navigation', () => {
+  const result = layout('<p>Content</p>', {
+    title: 'Test Page',
+  });
+
+  // Sidebar should have id="cms-nav" and popover attribute
+  assertStringIncludes(result, 'id="cms-nav"');
+  assertStringIncludes(result, 'popover');
+});
+
+Deno.test('layout: menu toggle has correct accessibility attributes', () => {
+  const result = layout('<p>Content</p>', {
+    title: 'Test Page',
+  });
+
+  // Toggle button should have:
+  // - type="button" (prevent form submission)
+  // - popovertarget="cms-nav" (control the popover)
+  // - aria-controls="cms-nav" (accessibility association)
+  // - aria-label (accessible name)
+  assertStringIncludes(result, 'type="button"');
+  assertStringIncludes(result, 'popovertarget="cms-nav"');
+  assertStringIncludes(result, 'aria-controls="cms-nav"');
+  assertStringIncludes(result, 'aria-label="Menu"');
+  // SVG should be aria-hidden
+  assertStringIncludes(result, 'aria-hidden="true"');
+});


### PR DESCRIPTION
- Add hamburger menu button in header (visible on mobile only)
- Sidebar uses native popover attribute for light-dismiss behavior
- Graceful fallback: sidebar always visible if popover not supported
- Uses @supports selector(:popover-open) to only show toggle when API works