### PR TITLE
feat(cms): add renderField hook support for list view

### DIFF
--- a/apps/demo/.env.example
+++ b/apps/demo/.env.example
@@ -1,7 +1,7 @@
 # Copy this file to .env and customize values
 # Generate secrets with: deno eval "console.log(crypto.randomUUID() + crypto.randomUUID())"
 
-# NODE_ENV=local
+NODE_ENV=local
 
 # Demo secrets - DO NOT use in production
 CMS_CSRF_SECRET=demo-csrf-secret-at-least-32-characters-long

--- a/apps/demo/schema.ts
+++ b/apps/demo/schema.ts
@@ -128,16 +128,16 @@ export const sauces = pgTable('sauces', {
  * Uses JSONB content with Puck visual editor (vs sauces which use markdown).
  */
 export const pages = pgTable('pages', {
-  id: serial('id').primaryKey(),
+  id: serial('id').primaryKey().$cms({ hidden: true }),
   title: varchar('title', { length: 255 }),
   slug: varchar('slug', { length: 255 }).unique()
     .$defaultFn(() => `draft-${crypto.randomUUID().slice(0, 8)}`),
   // JSON content edited with Puck visual editor
   content: jsonb('content').$cms({ plugins: { puck: true } }),
-  published: boolean('published').default(false).notNull(),
   sortOrder: integer('sort_order').default(0).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  published: boolean('published').default(false).notNull(),
 }).$cms({
   autoDraft: true,
   frontendUrl: (page) => page.published ? `/${page.slug}` : null,

--- a/packages/cms/crud.ts
+++ b/packages/cms/crud.ts
@@ -4,6 +4,7 @@ import { asc, desc, sql } from 'drizzle-orm';
 import type { Table } from 'drizzle-orm';
 
 import type { IntrospectedTable } from '@hotsauce/core';
+import { mapColumnToField } from '@hotsauce/core';
 
 import { alert, layout, pagination } from '@hotsauce/ui';
 import { listView } from '@hotsauce/ui';
@@ -38,12 +39,14 @@ import {
   redirectWithFlash,
   wantsJson,
 } from './http.ts';
-import { cmsUrl, formatTableName } from './router.ts';
+import { cmsUrl, formatColumnName, formatTableName } from './router.ts';
 import type {
+  CellOverrides,
   DetailViewOptions,
   EditViewOptions,
   FieldUIOverride,
   LayoutOptions,
+  ListColumn,
   ListViewOptions,
   NavItem,
 } from '@hotsauce/ui';
@@ -810,9 +813,89 @@ export async function handleList(ctx: RouteContext): Promise<Response> {
     // Table view (default for non-thumbnail tables, or explicit ?view=table)
 
     // Build columns for list, filtered by readable columns
-    const listColumns = getListColumns(table).filter(
+    const listColumns: ListColumn[] = getListColumns(table).filter(
       (col) => columnResult.readableColumns.includes(col.name ?? col.key),
     );
+
+    // Find columns with plugin config and add any that were filtered out (e.g., json fields)
+    const existingKeys = new Set(listColumns.map((c) => c.key));
+    const pluginColumns: Array<
+      {
+        col: typeof table.columns[number];
+        field: ReturnType<typeof mapColumnToField>;
+      }
+    > = [];
+
+    for (const col of table.columns) {
+      // Skip columns not readable by this user
+      if (!columnResult.readableColumns.includes(col.name)) continue;
+
+      // Check if column has any plugin config
+      const plugins = col.cmsOptions?.plugins;
+      if (!plugins || Object.keys(plugins).length === 0) continue;
+
+      const field = mapColumnToField(col);
+      pluginColumns.push({ col, field });
+
+      // Add column if it was filtered out (e.g., json field)
+      if (!existingKeys.has(col.propertyName)) {
+        listColumns.push({
+          key: col.propertyName,
+          name: col.name,
+          label: formatColumnName(col.name),
+        });
+      }
+    }
+
+    // Build cell overrides by calling renderField hook for each plugin column
+    const cellOverrides: CellOverrides = new Map();
+
+    if (ctx.pluginService && pluginColumns.length > 0) {
+      const user = getPluginUser(ctx);
+      const pluginService = ctx.pluginService;
+
+      // Build all hook calls upfront, then execute in parallel
+      const hookCalls = records.flatMap((record) => {
+        const id = record[pkCol.propertyName] as string | number;
+        return pluginColumns.map(({ col, field }) => {
+          const uiCtx: UIRenderFieldContext = {
+            table: table.name,
+            field: toUIFieldInfo(field),
+            value: (record[col.propertyName] ?? null) as UIRenderFieldContext[
+              'value'
+            ],
+            recordId: id,
+            view: 'list',
+            user,
+          };
+          return {
+            id,
+            colKey: col.propertyName,
+            uiCtx,
+          };
+        });
+      });
+
+      const results = await Promise.all(
+        hookCalls.map(async ({ id, colKey, uiCtx }) => ({
+          id,
+          colKey,
+          override: await pluginService.renderField(uiCtx),
+        })),
+      );
+
+      // Group results by record ID
+      for (const { id, colKey, override } of results) {
+        if (override) {
+          let recordOverrides = cellOverrides.get(id);
+          if (!recordOverrides) {
+            recordOverrides = {};
+            cellOverrides.set(id, recordOverrides);
+          }
+          recordOverrides[colKey] = override;
+        }
+      }
+    }
 
     // Fetch relation data for FK columns
     const relationData = await fetchAllRelationOptions(options, table);
@@ -851,6 +934,7 @@ export async function handleList(ctx: RouteContext): Promise<Response> {
       listOptions,
       relationData,
       m2mDisplayData,
+      cellOverrides,
     );
   }
 

--- a/packages/cms/crud.ts
+++ b/packages/cms/crud.ts
@@ -827,6 +827,9 @@ export async function handleList(ctx: RouteContext): Promise<Response> {
     > = [];
 
     for (const col of table.columns) {
+      // Skip hidden columns
+      if (col.cmsOptions?.hidden) continue;
+
       // Skip columns not readable by this user
       if (!columnResult.readableColumns.includes(col.name)) continue;
 

--- a/packages/cms/plugins/service.ts
+++ b/packages/cms/plugins/service.ts
@@ -491,12 +491,12 @@ export class PluginService {
     if (allPlugins.length === 0) return null;
 
     // Apply plugin filters
-    // Use 'read' action for UI hooks since we're rendering a view
+    // Use 'create' action only for create view, 'read' for all others (edit, detail, list)
     const plugins = this.applyFilter(
       allPlugins,
       'ui:renderField',
       ctx.table,
-      ctx.view === 'edit' ? 'read' : 'create',
+      ctx.view === 'create' ? 'create' : 'read',
       ctx.user,
     );
     if (plugins.length === 0) return null;

--- a/packages/cms/plugins/service.ts
+++ b/packages/cms/plugins/service.ts
@@ -479,7 +479,7 @@ export class PluginService {
 
   /**
    * Execute UI renderField hook for all plugins.
-   * Called when rendering edit/create forms.
+   * Called when rendering any view (list, detail, edit, create).
    * Returns first non-null override, or null for default rendering.
    *
    * @returns Field UI override or null

--- a/packages/cms/tests/integration_renderfield_test.ts
+++ b/packages/cms/tests/integration_renderfield_test.ts
@@ -6,7 +6,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { drizzle } from 'drizzle-orm/pglite';
 import { sql } from 'drizzle-orm';
 import { createCmsHandler } from '../mod.ts';
-import type { InProcessPluginConfig } from '../plugins/types.ts';
+import type { FilterContext, InProcessPluginConfig } from '../plugins/types.ts';
 import type { UIRenderFieldContext } from '@hotsauce/workers';
 import {
   createPagesTable,
@@ -607,6 +607,184 @@ Deno.test('integration: hidden columns with plugins are not shown in list view',
     false,
     'Hidden column plugin links should not appear in list view',
   );
+
+  await client.close();
+});
+
+Deno.test('integration: renderField filter receives correct action for each view', async (t) => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema: schemaWithPlugins });
+  await createPagesTable(db);
+
+  async function resetDb() {
+    await db.execute(sql`TRUNCATE TABLE pages RESTART IDENTITY CASCADE`);
+  }
+
+  // Track actions received by the filter for each view
+  const filterActions: { view: string; action: string }[] = [];
+
+  /**
+   * Create a plugin that records filter context and always returns a link
+   */
+  function createFilterTrackingPlugin(): InProcessPluginConfig {
+    return {
+      name: 'filter-tracker',
+      filter: (ctx: FilterContext) => {
+        // Only track ui:renderField hook calls
+        if (ctx.hookType === 'ui:renderField') {
+          filterActions.push({ view: 'unknown', action: ctx.action });
+        }
+        return true; // Always allow
+      },
+      hooks: {
+        ui: {
+          renderField: (ctx: UIRenderFieldContext) => {
+            // Update the last filter action entry with the actual view
+            const last = filterActions[filterActions.length - 1];
+            if (last && last.view === 'unknown') {
+              last.view = ctx.view;
+            }
+
+            if (!ctx.field.plugin) return null;
+            return {
+              link: { label: 'Test Link', href: '/test' },
+            };
+          },
+        },
+      },
+    };
+  }
+
+  await t.step('list view passes action=read to filter', async () => {
+    await resetDb();
+    filterActions.length = 0; // Clear previous calls
+
+    await db.insert(pages).values({ title: 'Test', content: { data: 1 } });
+
+    const plugin = createFilterTrackingPlugin();
+
+    const handler = createCmsHandler({
+      csrfSecret: TEST_CSRF_SECRET,
+      auth: 'dangerously-open',
+      policies: 'dangerously-open',
+      db,
+      schema: schemaWithPlugins,
+      basePath: '/admin',
+      plugins: [plugin],
+    });
+
+    await handler(new Request('http://localhost/admin/pages'));
+
+    // Find the filter call for list view
+    const listCalls = filterActions.filter((a) => a.view === 'list');
+    assertEquals(
+      listCalls.length > 0,
+      true,
+      'renderField should be called for list view',
+    );
+    assertEquals(
+      listCalls[0]!.action,
+      'read',
+      'list view should pass action=read to filter (viewing existing records)',
+    );
+  });
+
+  await t.step('detail view passes action=read to filter', async () => {
+    await resetDb();
+    filterActions.length = 0;
+
+    await db.insert(pages).values({ title: 'Test', content: { data: 1 } });
+
+    const plugin = createFilterTrackingPlugin();
+
+    const handler = createCmsHandler({
+      csrfSecret: TEST_CSRF_SECRET,
+      auth: 'dangerously-open',
+      policies: 'dangerously-open',
+      db,
+      schema: schemaWithPlugins,
+      basePath: '/admin',
+      plugins: [plugin],
+    });
+
+    await handler(new Request('http://localhost/admin/pages/1'));
+
+    const detailCalls = filterActions.filter((a) => a.view === 'detail');
+    assertEquals(
+      detailCalls.length > 0,
+      true,
+      'renderField should be called for detail view',
+    );
+    assertEquals(
+      detailCalls[0]!.action,
+      'read',
+      'detail view should pass action=read to filter (viewing existing record)',
+    );
+  });
+
+  await t.step('create view passes action=create to filter', async () => {
+    await resetDb();
+    filterActions.length = 0;
+
+    const plugin = createFilterTrackingPlugin();
+
+    const handler = createCmsHandler({
+      csrfSecret: TEST_CSRF_SECRET,
+      auth: 'dangerously-open',
+      policies: 'dangerously-open',
+      db,
+      schema: schemaWithPlugins,
+      basePath: '/admin',
+      plugins: [plugin],
+    });
+
+    await handler(new Request('http://localhost/admin/pages/new'));
+
+    const createCalls = filterActions.filter((a) => a.view === 'create');
+    assertEquals(
+      createCalls.length > 0,
+      true,
+      'renderField should be called for create view',
+    );
+    assertEquals(
+      createCalls[0]!.action,
+      'create',
+      'create view should pass action=create to filter (creating new record)',
+    );
+  });
+
+  await t.step('edit view passes action=read to filter', async () => {
+    await resetDb();
+    filterActions.length = 0;
+
+    await db.insert(pages).values({ title: 'Test', content: { data: 1 } });
+
+    const plugin = createFilterTrackingPlugin();
+
+    const handler = createCmsHandler({
+      csrfSecret: TEST_CSRF_SECRET,
+      auth: 'dangerously-open',
+      policies: 'dangerously-open',
+      db,
+      schema: schemaWithPlugins,
+      basePath: '/admin',
+      plugins: [plugin],
+    });
+
+    await handler(new Request('http://localhost/admin/pages/1/edit'));
+
+    const editCalls = filterActions.filter((a) => a.view === 'edit');
+    assertEquals(
+      editCalls.length > 0,
+      true,
+      'renderField should be called for edit view',
+    );
+    assertEquals(
+      editCalls[0]!.action,
+      'read',
+      'edit view should pass action=read to filter (editing existing record)',
+    );
+  });
 
   await client.close();
 });

--- a/packages/cms/tests/integration_renderfield_test.ts
+++ b/packages/cms/tests/integration_renderfield_test.ts
@@ -534,3 +534,79 @@ Deno.test('integration: renderField produces cellOverrides in list view', async 
 
   await client.close();
 });
+
+Deno.test('integration: hidden columns with plugins are not shown in list view', async () => {
+  // Import pg-core directly for this test's custom schema
+  const { pgTable, serial, varchar, json, timestamp } = await import(
+    'drizzle-orm/pg-core'
+  );
+
+  // Define a schema with a hidden column that also has plugin config
+  const pagesWithHidden = pgTable('pages', {
+    id: serial('id').primaryKey(),
+    title: varchar('title', { length: 200 }).notNull(),
+    // This column has BOTH hidden: true AND plugins config
+    content: json('content').$cms({ hidden: true, plugins: { puck: true } }),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+  });
+  const schemaWithHiddenPlugin = { pages: pagesWithHidden };
+
+  const client = new PGlite();
+  const db = drizzle(client, { schema: schemaWithHiddenPlugin });
+
+  // Create table
+  await db.execute(sql`
+    CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(200) NOT NULL,
+      content JSON,
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await db.insert(pagesWithHidden).values({
+    title: 'Test Page',
+    content: { blocks: [] },
+  });
+
+  // Track if renderField was called for the hidden column
+  const calledForColumns: string[] = [];
+
+  const plugin = createRenderFieldPlugin('puck', {
+    onRenderField: (ctx) => {
+      calledForColumns.push(ctx.field.name);
+    },
+  });
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema: schemaWithHiddenPlugin,
+    basePath: '/admin',
+    plugins: [plugin],
+  });
+
+  // GET list view
+  const response = await handler(new Request('http://localhost/admin/pages'));
+
+  assertEquals(response.status, 200);
+  const html = await response.text();
+
+  // The hidden column should NOT trigger renderField
+  assertEquals(
+    calledForColumns.includes('content'),
+    false,
+    'renderField should not be called for hidden columns',
+  );
+
+  // The custom link should NOT appear (since the column is hidden)
+  assertEquals(
+    html.includes(CUSTOM_LINK_LABEL),
+    false,
+    'Hidden column plugin links should not appear in list view',
+  );
+
+  await client.close();
+});

--- a/packages/cms/tests/integration_renderfield_test.ts
+++ b/packages/cms/tests/integration_renderfield_test.ts
@@ -439,7 +439,8 @@ Deno.test('integration: renderField produces cellOverrides in list view', async 
     assertEquals(response.status, 200);
     const html = await response.text();
 
-    // Plugin's link label should appear in the table cells
+    // Both valueSummary and link label should appear in the table cells
+    assertStringIncludes(html, CUSTOM_VALUE_SUMMARY);
     assertStringIncludes(html, CUSTOM_LINK_LABEL);
     // The link href should also be present
     assertStringIncludes(html, CUSTOM_LINK_HREF);
@@ -785,6 +786,98 @@ Deno.test('integration: renderField filter receives correct action for each view
       'edit view should pass action=read to filter (editing existing record)',
     );
   });
+
+  await client.close();
+});
+
+Deno.test('integration: list view link supports target=_blank with rel=noopener', async () => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema: schemaWithPlugins });
+  await createPagesTable(db);
+
+  await db.insert(pages).values({ title: 'Test', content: { data: 1 } });
+
+  const plugin = createRenderFieldPlugin('puck', {
+    link: {
+      label: 'Open Editor',
+      href: '/editor/1',
+      target: '_blank',
+    },
+  });
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema: schemaWithPlugins,
+    basePath: '/admin',
+    plugins: [plugin],
+  });
+
+  const response = await handler(new Request('http://localhost/admin/pages'));
+  assertEquals(response.status, 200);
+
+  const html = await response.text();
+
+  // Should include target="_blank" and rel="noopener" for security
+  assertStringIncludes(html, 'target="_blank"');
+  assertStringIncludes(html, 'rel="noopener"');
+  // Should show link label with arrow for external links
+  assertStringIncludes(html, 'Open Editor ↗');
+
+  await client.close();
+});
+
+Deno.test('integration: list view renders valueSummary when no link', async () => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema: schemaWithPlugins });
+  await createPagesTable(db);
+
+  await db.insert(pages).values({ title: 'Test', content: { data: 1 } });
+
+  // Plugin returns only valueSummary, no link
+  // Use 'puck' as plugin name to match the schema declaration
+  const plugin: InProcessPluginConfig = {
+    name: 'puck',
+    filter: 'dangerously-open',
+    hooks: {
+      ui: {
+        renderField: (ctx: UIRenderFieldContext) => {
+          // Only respond for the content column which has puck plugin config
+          if (!ctx.field.plugin) return null;
+          return {
+            valueSummary: 'Custom Summary Text',
+            // No link - testing valueSummary-only display
+          };
+        },
+      },
+    },
+  };
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema: schemaWithPlugins,
+    basePath: '/admin',
+    plugins: [plugin],
+  });
+
+  const response = await handler(new Request('http://localhost/admin/pages'));
+  assertEquals(response.status, 200);
+
+  const html = await response.text();
+
+  // Should show the valueSummary as cell text
+  assertStringIncludes(html, 'Custom Summary Text');
+  // Should NOT be a link (no <a> tag with our text)
+  assertEquals(
+    html.includes('<a') && html.includes('Custom Summary Text</a>'),
+    false,
+    'valueSummary should not be rendered as a link',
+  );
 
   await client.close();
 });

--- a/packages/cms/tests/integration_renderfield_test.ts
+++ b/packages/cms/tests/integration_renderfield_test.ts
@@ -400,3 +400,137 @@ Deno.test('integration: fieldOverrides fileUrl is passed to detail view', async 
 
   await client.close();
 });
+
+Deno.test('integration: renderField produces cellOverrides in list view', async (t) => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema: schemaWithPlugins });
+  await createPagesTable(db);
+
+  async function resetDb() {
+    await db.execute(sql`TRUNCATE TABLE pages RESTART IDENTITY CASCADE`);
+  }
+
+  await t.step('list view includes renderField link output', async () => {
+    await resetDb();
+
+    // Insert pages with content
+    await db.insert(pages).values([
+      { title: 'Page One', content: { blocks: [1] } },
+      { title: 'Page Two', content: { blocks: [2] } },
+    ]);
+
+    const plugin = createRenderFieldPlugin('puck');
+
+    const handler = createCmsHandler({
+      csrfSecret: TEST_CSRF_SECRET,
+      auth: 'dangerously-open',
+      policies: 'dangerously-open',
+      db,
+      schema: schemaWithPlugins,
+      basePath: '/admin',
+      plugins: [plugin],
+    });
+
+    // GET list view
+    const response = await handler(
+      new Request('http://localhost/admin/pages'),
+    );
+
+    assertEquals(response.status, 200);
+    const html = await response.text();
+
+    // Plugin's link label should appear in the table cells
+    assertStringIncludes(html, CUSTOM_LINK_LABEL);
+    // The link href should also be present
+    assertStringIncludes(html, CUSTOM_LINK_HREF);
+  });
+
+  await t.step(
+    'renderField receives correct context for list view',
+    async () => {
+      await resetDb();
+
+      await db.insert(pages).values({
+        title: 'List Context Test',
+        content: { listData: 'test' },
+      });
+
+      let receivedCtx: UIRenderFieldContext | null = null;
+
+      const plugin = createRenderFieldPlugin('puck', {
+        onRenderField: (ctx) => {
+          if (ctx.field.name === 'content' && ctx.view === 'list') {
+            receivedCtx = ctx;
+          }
+        },
+      });
+
+      const handler = createCmsHandler({
+        csrfSecret: TEST_CSRF_SECRET,
+        auth: 'dangerously-open',
+        policies: 'dangerously-open',
+        db,
+        schema: schemaWithPlugins,
+        basePath: '/admin',
+        plugins: [plugin],
+      });
+
+      await handler(new Request('http://localhost/admin/pages'));
+
+      // Verify context for list view
+      assertEquals(receivedCtx!.table, 'pages');
+      assertEquals(receivedCtx!.view, 'list');
+      assertEquals(receivedCtx!.recordId, 1); // PGlite returns number, not string
+      assertEquals(receivedCtx!.field.name, 'content');
+      assertEquals(
+        (receivedCtx!.value as Record<string, unknown>)?.listData,
+        'test',
+      );
+      assertEquals(receivedCtx!.field.plugin, true); // puck: true from schema
+    },
+  );
+
+  await t.step(
+    'renderField is called for each record in list view',
+    async () => {
+      await resetDb();
+
+      await db.insert(pages).values([
+        { title: 'Multi 1', content: { id: 'a' } },
+        { title: 'Multi 2', content: { id: 'b' } },
+        { title: 'Multi 3', content: { id: 'c' } },
+      ]);
+
+      const receivedRecordIds: (string | number)[] = [];
+
+      const plugin = createRenderFieldPlugin('puck', {
+        onRenderField: (ctx) => {
+          if (
+            ctx.field.name === 'content' && ctx.view === 'list' && ctx.recordId
+          ) {
+            receivedRecordIds.push(ctx.recordId);
+          }
+        },
+      });
+
+      const handler = createCmsHandler({
+        csrfSecret: TEST_CSRF_SECRET,
+        auth: 'dangerously-open',
+        policies: 'dangerously-open',
+        db,
+        schema: schemaWithPlugins,
+        basePath: '/admin',
+        plugins: [plugin],
+      });
+
+      await handler(new Request('http://localhost/admin/pages'));
+
+      // Should have been called for each of the 3 records
+      assertEquals(receivedRecordIds.length, 3);
+      // IDs should be 1, 2, 3 (order may vary due to parallel execution)
+      assertEquals(new Set(receivedRecordIds), new Set([1, 2, 3]));
+    },
+  );
+
+  await client.close();
+});

--- a/packages/ui/mod.ts
+++ b/packages/ui/mod.ts
@@ -61,6 +61,7 @@ export { deleteForm, form } from './forms/form.ts';
 // Views - Page templates for CRUD operations
 // ─────────────────────────────────────────────────────────────
 export type {
+  CellOverrides,
   ListColumn,
   ListViewOptions,
   ManyToManyDisplayData,

--- a/packages/ui/views/list.ts
+++ b/packages/ui/views/list.ts
@@ -3,6 +3,7 @@
 import { attrs, escapeHtml, html, raw } from '../html.ts';
 import type { CMSField } from '@hotsauce/core';
 import { isValidFileReference } from '@hotsauce/core';
+import type { FieldUIOverride } from '@hotsauce/workers';
 import type { RelationOption } from '../forms/inputs.ts';
 import {
   viewToggle,
@@ -34,6 +35,15 @@ export interface ListColumn {
   /** Format function for cell value */
   format?: (value: unknown) => string;
 }
+
+/**
+ * Cell overrides map: recordId -> columnKey -> FieldUIOverride
+ * Used to render plugin links in list cells.
+ */
+export type CellOverrides = Map<
+  string | number,
+  Record<string, FieldUIOverride>
+>;
 
 /**
  * Options for list view
@@ -107,6 +117,7 @@ export function listTable(
   options: ListViewOptions,
   relationData: Record<string, RelationOption[]> = {},
   manyToManyData: Map<string | number, ManyToManyDisplayData[]> = new Map(),
+  cellOverrides: CellOverrides = new Map(),
 ): string {
   const primaryKey = options.primaryKey ?? 'id';
   const showActions = options.showEdit || options.showDelete ||
@@ -149,8 +160,17 @@ export function listTable(
   ).join('\n      ');
 
   const rows = records.map((record) => {
-    const id = record[primaryKey];
+    const id = record[primaryKey] as string | number;
+    const recordOverrides = cellOverrides.get(id) ?? {};
     const cells = columns.map((col) => {
+      // Check for plugin override with link
+      const override = recordOverrides[col.key];
+      if (override?.link) {
+        const { href, label } = override.link;
+        return `<td class="cms-td"><a href="${
+          escapeHtml(href)
+        }" class="cms-action">${escapeHtml(label)}</a></td>`;
+      }
       const value = record[col.key];
       const formatted = col.format
         ? col.format(value)
@@ -257,6 +277,7 @@ export function listView(
   options: ListViewOptions,
   relationData: Record<string, RelationOption[]> = {},
   manyToManyData: Map<string | number, ManyToManyDisplayData[]> = new Map(),
+  cellOverrides: CellOverrides = new Map(),
 ): string {
   const viewToggleHtml = options.viewToggle
     ? viewToggle(options.viewToggle)
@@ -272,7 +293,16 @@ export function listView(
             .baseUrl}/new" class="cms-btn cms-btn-primary">Create New</a>
         </div>
       </header>
-      ${raw(listTable(columns, records, options, relationData, manyToManyData))}
+      ${raw(
+        listTable(
+          columns,
+          records,
+          options,
+          relationData,
+          manyToManyData,
+          cellOverrides,
+        ),
+      )}
     </div>
   `;
 }

--- a/packages/ui/views/list.ts
+++ b/packages/ui/views/list.ts
@@ -1,6 +1,6 @@
 // List view - table of records
 
-import { attrs, escapeHtml, html, raw } from '../html.ts';
+import { attrs, escapeHtml, getSafeUrl, html, raw } from '../html.ts';
 import type { CMSField } from '@hotsauce/core';
 import { isValidFileReference } from '@hotsauce/core';
 import type { FieldUIOverride } from '@hotsauce/workers';
@@ -174,16 +174,22 @@ export function listTable(
           : '';
 
         // Build link button (e.g., "Edit with Puck ↗")
+        // Validate URL to prevent javascript:/data: scheme injection
         let linkHtml = '';
         if (override.link) {
-          const { href, label, target } = override.link;
-          const targetAttr = target === '_blank'
-            ? ' target="_blank" rel="noopener"'
-            : '';
-          const arrow = target === '_blank' ? ' ↗' : '';
-          linkHtml = `<a href="${
-            escapeHtml(href)
-          }" class="cms-action"${targetAttr}>${escapeHtml(label)}${arrow}</a>`;
+          const safeHref = getSafeUrl(override.link.href);
+          if (safeHref) {
+            const { label, target } = override.link;
+            const targetAttr = target === '_blank'
+              ? ' target="_blank" rel="noopener"'
+              : '';
+            const arrow = target === '_blank' ? ' ↗' : '';
+            linkHtml = `<a href="${
+              escapeHtml(safeHref)
+            }" class="cms-action"${targetAttr}>${
+              escapeHtml(label)
+            }${arrow}</a>`;
+          }
         }
 
         // Show both summary and link if both exist

--- a/packages/ui/views/list.ts
+++ b/packages/ui/views/list.ts
@@ -196,7 +196,11 @@ export function listTable(
         const content = summaryHtml && linkHtml
           ? `${summaryHtml} ${linkHtml}`
           : summaryHtml || linkHtml;
-        return `<td class="cms-td">${content}</td>`;
+
+        // Only use override if we have content, otherwise fall back to default
+        if (content) {
+          return `<td class="cms-td">${content}</td>`;
+        }
       }
       const value = record[col.key];
       const formatted = col.format

--- a/packages/ui/views/list.ts
+++ b/packages/ui/views/list.ts
@@ -163,13 +163,34 @@ export function listTable(
     const id = record[primaryKey] as string | number;
     const recordOverrides = cellOverrides.get(id) ?? {};
     const cells = columns.map((col) => {
-      // Check for plugin override with link
+      // Check for plugin override
       const override = recordOverrides[col.key];
-      if (override?.link) {
-        const { href, label } = override.link;
-        return `<td class="cms-td"><a href="${
-          escapeHtml(href)
-        }" class="cms-action">${escapeHtml(label)}</a></td>`;
+      if (override?.link || override?.valueSummary) {
+        // Build summary text (e.g., "8 blocks")
+        const summaryHtml = override.valueSummary
+          ? `<span class="cms-value-summary">${
+            escapeHtml(override.valueSummary)
+          }</span>`
+          : '';
+
+        // Build link button (e.g., "Edit with Puck ↗")
+        let linkHtml = '';
+        if (override.link) {
+          const { href, label, target } = override.link;
+          const targetAttr = target === '_blank'
+            ? ' target="_blank" rel="noopener"'
+            : '';
+          const arrow = target === '_blank' ? ' ↗' : '';
+          linkHtml = `<a href="${
+            escapeHtml(href)
+          }" class="cms-action"${targetAttr}>${escapeHtml(label)}${arrow}</a>`;
+        }
+
+        // Show both summary and link if both exist
+        const content = summaryHtml && linkHtml
+          ? `${summaryHtml} ${linkHtml}`
+          : summaryHtml || linkHtml;
+        return `<td class="cms-td">${content}</td>`;
       }
       const value = record[col.key];
       const formatted = col.format

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -186,7 +186,7 @@ export interface UIRenderFieldContext {
   /** Record ID (undefined on create) */
   recordId?: string | number;
   /** View type: where the field is being rendered */
-  view: 'edit' | 'create' | 'detail';
+  view: 'edit' | 'create' | 'detail' | 'list';
   /** Authenticated user info (if available) */
   user?: {
     sub: string;


### PR DESCRIPTION
- Add 'list' to UIRenderFieldContext view union
- Call renderField for plugin columns in handleList
- Build cellOverrides map for per-record, per-column link rendering
- Export CellOverrides type from ui package
- Update list.ts to accept and render cell overrides
- Add integration tests for list view renderField context