### PR TITLE
Add label-driven agent workflow (sandcastle) for issues

### DIFF
--- a/.github/workflows/agent-on-issue.yml
+++ b/.github/workflows/agent-on-issue.yml
@@ -1,0 +1,108 @@
+name: Agent on Issue
+
+# Label-driven state machine on issues, powered by sandcastle (@ai-hero/sandcastle)
+# running Claude Code:
+#   agent:explore   -> research the issue (read-only) and post triage notes
+#   agent:implement -> implement, push a branch, open a PR, request a Copilot review
+# Status labels: agent:in-progress, agent:explored, agent:done, agent:blocked.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write # push the agent branch
+  issues: write # label transitions + comments
+
+concurrency:
+  group: agent-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  agent:
+    if: github.event.label.name == 'agent:explore' || github.event.label.name == 'agent:implement'
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      # 'agent:explore' -> explore, 'agent:implement' -> implement
+      MODE: ${{ github.event.label.name == 'agent:explore' && 'explore' || 'implement' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the agent branch is clean
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x # agent verifies via `deno task test`
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22 # runs the sandcastle orchestration script
+
+      - name: Install Claude Code CLI
+        run: npm i -g @anthropic-ai/claude-code # no-sandbox needs `claude` on PATH
+
+      - name: Mark in-progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "${{ github.event.label.name }}" \
+            --add-label "agent:in-progress"
+
+      - name: Run agent
+        id: agent
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          npm install --no-save @ai-hero/sandcastle tsx
+          # Reads MODE; sets step outputs `mode` and (implement only) `branch`.
+          # explore mode writes .sandcastle/triage-notes.md
+          npx tsx .sandcastle/run-issue.ts
+
+      # ---- explore branch ----
+      - name: Post triage notes
+        if: success() && env.MODE == 'explore'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body-file .sandcastle/triage-notes.md
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label agent:in-progress --add-label agent:explored
+
+      # ---- implement branch ----
+      - name: Open PR and request Copilot review
+        if: success() && env.MODE == 'implement' && steps.agent.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.PR_CREATE_TOKEN }} # PAT -> triggers test.yml on the PR
+          BRANCH: ${{ steps.agent.outputs.branch }}
+        run: |
+          PR_URL=$(gh pr create --base main --head "$BRANCH" \
+            --title "Agent: $ISSUE_TITLE (#$ISSUE_NUMBER)" \
+            --body "Automated work for #$ISSUE_NUMBER. Closes #$ISSUE_NUMBER.")
+          gh pr edit "$PR_URL" --add-reviewer @copilot \
+            || echo "::warning::Could not request Copilot review (is Copilot code review enabled?)"
+          echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
+
+      - name: Finalize implement
+        if: success() && env.MODE == 'implement'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label agent:in-progress --add-label agent:done
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "Opened PR: ${PR_URL:-(no changes produced)}"
+
+      # ---- failure path (both modes) ----
+      - name: Mark blocked
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label agent:in-progress --add-label agent:blocked || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "Agent run failed in **$MODE** mode. See workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+# Transient artifact written by run-issue.ts in explore mode
+triage-notes.md
+node_modules/

--- a/.sandcastle/README.md
+++ b/.sandcastle/README.md
@@ -1,0 +1,54 @@
+# Agent on Issue
+
+A label-driven state machine that runs a Claude Code agent on GitHub issues via
+[sandcastle](https://github.com/mattpocock/sandcastle) (`@ai-hero/sandcastle`).
+
+Workflow: [`.github/workflows/agent-on-issue.yml`](../.github/workflows/agent-on-issue.yml)
+Orchestration: [`run-issue.ts`](./run-issue.ts)
+
+## State machine
+
+| Add this label    | Agent does                                                       | On start                                 | On success                                        | On failure                                       |
+| ----------------- | ---------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
+| `agent:explore`   | Researches the issue read-only, writes triage notes              | −`agent:explore`, +`agent:in-progress`   | −`in-progress`, +`agent:explored`, comments notes | −`in-progress`, +`agent:blocked`, comments error |
+| `agent:implement` | Implements, pushes a branch, opens a PR, requests Copilot review | −`agent:implement`, +`agent:in-progress` | −`in-progress`, +`agent:done`, comments PR link   | −`in-progress`, +`agent:blocked`, comments error |
+
+Typical flow: label `agent:explore`, review the triage comment, then label
+`agent:implement` to ship a PR.
+
+## One-time setup
+
+1. **Labels** (exact strings): `agent:explore`, `agent:implement`, `agent:in-progress`,
+   `agent:explored`, `agent:done`, `agent:blocked`.
+2. **Secret `CLAUDE_CODE_OAUTH_TOKEN`** — from `claude setup-token`.
+3. **Secret `PR_CREATE_TOKEN`** — fine-grained PAT scoped to this repo with
+   **Pull requests: write** (Metadata: read is added automatically). Opening the PR with a
+   PAT rather than the built-in `GITHUB_TOKEN` is what lets `test.yml` run on the agent's PR.
+   The token owner needs write access to the repo.
+4. **Enable Copilot code review** for the repo/org. If it isn't enabled, the review-request
+   step soft-fails with a warning instead of failing the run.
+
+## Why these choices
+
+- **`no-sandbox`**: the GitHub Actions runner is already an ephemeral, disposable VM, so the
+  agent runs directly on it — no Dockerfile to build or maintain.
+- **Branch push uses `GITHUB_TOKEN`; PR creation uses the PAT**: pushing a branch is a
+  Contents-write the runner token already has, and pushing a feature branch doesn't trigger
+  `test.yml`. Opening the PR with the PAT is what fires `test.yml` (GitHub suppresses workflow
+  triggers from the built-in token).
+
+## Local dry-run
+
+```bash
+export MODE=explore                 # or: implement
+export ISSUE_NUMBER=123
+export ISSUE_TITLE="Example"
+export ISSUE_BODY="Describe the task"
+export CLAUDE_CODE_OAUTH_TOKEN=...   # from `claude setup-token`
+npm install --no-save @ai-hero/sandcastle tsx
+npx tsx .sandcastle/run-issue.ts
+```
+
+`explore` produces `.sandcastle/triage-notes.md` and no commits. `implement` creates the
+`agent/issue-<n>` branch with commits (the `git push` only runs when `GITHUB_OUTPUT` is set,
+i.e. inside Actions).

--- a/.sandcastle/run-issue.ts
+++ b/.sandcastle/run-issue.ts
@@ -1,0 +1,74 @@
+// Sandcastle orchestration for the "Agent on Issue" workflow.
+//
+// Driven by the MODE env var set in .github/workflows/agent-on-issue.yml:
+//   explore   -> read-only research; writes triage notes to .sandcastle/triage-notes.md
+//   implement -> implements the change on a branch and pushes it
+//
+// Verified against @ai-hero/sandcastle@0.10.0:
+//   noSandbox()                         -> sandboxes/no-sandbox export
+//   claudeCode(model, { effort, permissionMode })
+//   run(...) -> RunResult { commits: { sha }[]; branch: string }
+//   branchStrategy: { type: "head" } | { type: "branch", branch }
+import { claudeCode, run } from '@ai-hero/sandcastle';
+import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const mode = process.env.MODE === 'explore' ? 'explore' : 'implement';
+const issue = process.env.ISSUE_NUMBER;
+if (!issue) throw new Error('ISSUE_NUMBER env var is required');
+
+const out = process.env.GITHUB_OUTPUT;
+const setOutput = (line: string) => {
+  if (out) appendFileSync(out, `${line}\n`);
+};
+
+const ctx = [
+  `Issue #${issue}`,
+  `Title: ${process.env.ISSUE_TITLE ?? '(no title)'}`,
+  `Body:`,
+  process.env.ISSUE_BODY ?? '(no description)',
+].join('\n');
+
+if (mode === 'explore') {
+  // Read-only research. `permissionMode: "plan"` keeps the agent out of edit
+  // mode; we also never push or open a PR here, so any stray writes are
+  // discarded with the ephemeral runner.
+  await run({
+    agent: claudeCode('claude-opus-4-8', {
+      effort: 'high',
+      permissionMode: 'plan',
+    }),
+    sandbox: noSandbox(),
+    branchStrategy: { type: 'head' },
+    prompt: `${ctx}
+
+Research this issue in the repo WITHOUT changing any source files. Investigate the
+root cause, the affected files, and a recommended implementation approach. Write your
+findings as markdown to \`.sandcastle/triage-notes.md\` (create the file).
+When done, output <promise>COMPLETE</promise>.`,
+  });
+  setOutput('mode=explore');
+} else {
+  const branch = `agent/issue-${issue}`;
+  const result = await run({
+    agent: claudeCode('claude-opus-4-8', { effort: 'high' }),
+    sandbox: noSandbox(),
+    branchStrategy: { type: 'branch', branch },
+    prompt: `${ctx}
+
+Implement the change in this Deno repo. Match the existing code patterns and conventions.
+Run \`deno task test\` and make it pass before finishing.
+When done, output <promise>COMPLETE</promise>.`,
+  });
+  setOutput('mode=implement');
+  if (result.commits.length > 0) {
+    // Push using the checkout-persisted GITHUB_TOKEN (contents: write).
+    execSync(`git push origin ${result.branch}`, { stdio: 'inherit' });
+    setOutput(`branch=${result.branch}`);
+  } else {
+    process.stdout.write(
+      'Agent produced no commits; skipping branch push and PR.\n',
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds an event-driven, label-driven agent state machine on issues, powered by [sandcastle](https://github.com/mattpocock/sandcastle) (`@ai-hero/sandcastle@0.10.0`) running Claude Code.

| Add this label | Agent does |
| --- | --- |
| `agent:explore` | Researches the issue **read-only**, posts triage notes as a comment → `agent:explored` |
| `agent:implement` | Implements, pushes a branch, opens a PR, requests a **GitHub Copilot** review → `agent:done` |

Status labels `agent:in-progress` / `agent:blocked` track each run.

## Files

- `.github/workflows/agent-on-issue.yml` — triggers on `issues: [labeled]`, gated to the two entry labels; manages label transitions, runs the agent, posts triage notes / opens PR + requests Copilot.
- `.sandcastle/run-issue.ts` — sandcastle orchestration (`noSandbox()` + `claudeCode(...)`; `permissionMode: "plan"` for read-only explore).
- `.sandcastle/README.md` — docs + local dry-run instructions.

## Design notes

- **`no-sandbox`**: the Actions runner is already an ephemeral VM, so the agent runs directly on it — no Dockerfile to maintain.
- **Branch push uses `GITHUB_TOKEN`; the PR is opened with `PR_CREATE_TOKEN`** (a fine-grained PAT, Pull requests: write) so the existing `test.yml` actually runs on the agent's PR — the built-in token can't trigger downstream workflows.

## Prerequisites (already configured)

- Secrets `CLAUDE_CODE_OAUTH_TOKEN`, `PR_CREATE_TOKEN`.
- Labels `agent:explore`, `agent:implement`, `agent:in-progress`, `agent:explored`, `agent:done`, `agent:blocked`.
- Copilot code review enabled.

> Note: `issues: labeled` triggers run from the workflow on the **default branch**, so the automation goes live once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)