### PR TITLE
Run the issue agent in a Docker sandbox (fixes CI permission hang)

### DIFF
--- a/.github/workflows/agent-on-issue.yml
+++ b/.github/workflows/agent-on-issue.yml
@@ -33,16 +33,19 @@ jobs:
         with:
           fetch-depth: 0 # full history so the agent branch is clean
 
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x # agent verifies via `deno task test`
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22 # runs the sandcastle orchestration script
 
-      - name: Install Claude Code CLI
-        run: npm i -g @anthropic-ai/claude-code # no-sandbox needs `claude` on PATH
+      # The agent (Claude Code) and `deno task test` run *inside* this image, so
+      # Deno/Claude live in the container, not on the runner. Build with the host
+      # UID/GID so sandcastle's bind-mounts share an owner with the runner user.
+      - name: Build agent sandbox image
+        run: |
+          docker build -t hotsauce-agent \
+            --build-arg AGENT_UID="$(id -u)" \
+            --build-arg AGENT_GID="$(id -g)" \
+            .sandcastle
 
       - name: Mark in-progress
         env:

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,52 @@
+# Sandbox image for the "Agent on Issue" workflow.
+#
+# Based on sandcastle's canonical Claude Code image (node base + a UID-aligned
+# `agent` user + the Claude Code CLI), with Deno added so the agent can run
+# `deno task test` for this repo.
+#
+# Build with host UID/GID so bind-mounted files share an owner (sandcastle's
+# docker() sandbox defaults the container UID/GID to the host user's):
+#   docker build -t hotsauce-agent \
+#     --build-arg AGENT_UID=$(id -u) --build-arg AGENT_GID=$(id -g) .sandcastle
+FROM node:22-bookworm
+
+# System dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Build-args for UID/GID alignment: defaults match the host user so image-built
+# files and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
+
+# Claude Code CLI (the agent the workflow runs)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Deno (so the agent can run `deno task test` for this repo)
+RUN curl -fsSL https://deno.land/install.sh | sh
+
+# Expose both CLIs on PATH
+ENV DENO_INSTALL="/home/agent/.deno"
+ENV PATH="/home/agent/.deno/bin:/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# Sandcastle bind-mounts the git worktree and overrides the working directory at
+# container start, then execs the agent itself; keep the container alive.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/README.md
+++ b/.sandcastle/README.md
@@ -30,14 +30,27 @@ Typical flow: label `agent:explore`, review the triage comment, then label
 
 ## Why these choices
 
-- **`no-sandbox`**: the GitHub Actions runner is already an ephemeral, disposable VM, so the
-  agent runs directly on it — no Dockerfile to build or maintain.
+- **Docker sandbox** (`docker()` + [`Dockerfile`](./Dockerfile)): the agent runs inside a
+  container — sandcastle's intended model, where the container is the safety boundary. This is
+  why we do **not** set `permissionMode`: sandcastle then passes `--dangerously-skip-permissions`
+  for us so the agent runs headlessly. Setting a `permissionMode` would suppress that flag and
+  re-introduce interactive approval prompts that hang in CI. The image bundles the Claude Code
+  CLI and Deno (for `deno task test`), built with the host UID/GID so bind-mounts share an owner.
 - **Branch push uses `GITHUB_TOKEN`; PR creation uses the PAT**: pushing a branch is a
   Contents-write the runner token already has, and pushing a feature branch doesn't trigger
   `test.yml`. Opening the PR with the PAT is what fires `test.yml` (GitHub suppresses workflow
   triggers from the built-in token).
 
 ## Local dry-run
+
+Requires Docker. First build the image (matches the workflow):
+
+```bash
+docker build -t hotsauce-agent \
+  --build-arg AGENT_UID="$(id -u)" --build-arg AGENT_GID="$(id -g)" .sandcastle
+```
+
+Then run the orchestrator:
 
 ```bash
 export MODE=explore                 # or: implement

--- a/.sandcastle/run-issue.mts
+++ b/.sandcastle/run-issue.mts
@@ -5,18 +5,33 @@
 //   implement -> implements the change on a branch and pushes it
 //
 // Verified against @ai-hero/sandcastle@0.10.0:
-//   noSandbox()                         -> sandboxes/no-sandbox export
-//   claudeCode(model, { effort, permissionMode })
+//   docker({ imageName })               -> sandboxes/docker export
+//   claudeCode(model, { effort, env })
 //   run(...) -> RunResult { commits: { sha }[]; branch: string }
 //   branchStrategy: { type: "head" } | { type: "branch", branch }
+//
+// Runs the agent in a Docker container (sandcastle's intended model): the
+// container is the safety boundary, so sandcastle passes
+// --dangerously-skip-permissions for us and the agent runs headlessly. We do
+// NOT set permissionMode (that would suppress the skip flag and re-introduce
+// interactive approval prompts that hang in CI).
 import { claudeCode, run } from '@ai-hero/sandcastle';
-import { noSandbox } from '@ai-hero/sandcastle/sandboxes/no-sandbox';
+import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
 import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
+
+// Must match the image tag built in the workflow.
+const IMAGE = 'hotsauce-agent';
 
 const mode = process.env.MODE === 'explore' ? 'explore' : 'implement';
 const issue = process.env.ISSUE_NUMBER;
 if (!issue) throw new Error('ISSUE_NUMBER env var is required');
+
+// Credentials forwarded into the container for the Claude Code CLI.
+const agentEnv: Record<string, string> = {};
+if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+  agentEnv.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+}
 
 const out = process.env.GITHUB_OUTPUT;
 const setOutput = (line: string) => {
@@ -31,16 +46,14 @@ const ctx = [
 ].join('\n');
 
 if (mode === 'explore') {
-  // Read-only research. `permissionMode: "plan"` keeps the agent out of edit
-  // mode; we also never push or open a PR here, so any stray writes are
-  // discarded with the ephemeral runner.
+  // Research only. The prompt asks the agent not to change source files, and we
+  // never push or open a PR here, so any stray writes are discarded with the
+  // ephemeral container/runner.
   await run({
-    agent: claudeCode('claude-opus-4-8', {
-      effort: 'high',
-      permissionMode: 'plan',
-    }),
-    sandbox: noSandbox(),
+    agent: claudeCode('claude-opus-4-8', { effort: 'high', env: agentEnv }),
+    sandbox: docker({ imageName: IMAGE }),
     branchStrategy: { type: 'head' },
+    logging: { type: 'stdout' },
     prompt: `${ctx}
 
 Research this issue in the repo WITHOUT changing any source files. Investigate the
@@ -52,9 +65,10 @@ When done, output <promise>COMPLETE</promise>.`,
 } else {
   const branch = `agent/issue-${issue}`;
   const result = await run({
-    agent: claudeCode('claude-opus-4-8', { effort: 'high' }),
-    sandbox: noSandbox(),
+    agent: claudeCode('claude-opus-4-8', { effort: 'high', env: agentEnv }),
+    sandbox: docker({ imageName: IMAGE }),
     branchStrategy: { type: 'branch', branch },
+    logging: { type: 'stdout' },
     prompt: `${ctx}
 
 Implement the change in this Deno repo. Match the existing code patterns and conventions.


### PR DESCRIPTION
## Problem

The first live run (issue #51) hung at `[Agent] Started` and would have timed out. Root cause: the `no-sandbox` provider does **not** pass `--dangerously-skip-permissions` — sandcastle only does that for non-`"none"` sandboxes (confirmed in `dist/index.js`: `dangerouslySkipPermissions: sandboxProvider.tag !== "none"`). So the agent ran in **interactive-permission mode** with no way to approve tools headlessly:

- **explore** (`permissionMode: "plan"`) couldn't write `.sandcastle/triage-notes.md`,
- **implement** (default mode) couldn't make edits.

Also, `permissionMode` and the skip flag are **mutually exclusive** (`dist/index.js`: `permissionMode ? --permission-mode … : dangerouslySkipPermissions ? --dangerously-skip-permissions : ""`), so setting any `permissionMode` re-introduces the prompts.

## Fix — use sandcastle's intended model: a container

Run the agent inside a Docker container, which **is** the safety boundary. Sandcastle then passes `--dangerously-skip-permissions` for us and the agent runs headlessly. We set **no** `permissionMode`.

This also aligns with the security posture from earlier discussion: `--dangerously-skip-permissions` is only safe *because* it's contained — far better than granting that on the bare runner alongside the repo/CLAUDE tokens.

## Changes

- **`.sandcastle/Dockerfile`** (new) — based on sandcastle's canonical Claude Code image (`node:22-bookworm` + UID-aligned `agent` user + Claude Code CLI via `claude.ai/install.sh`), with **Deno** added so the agent can run `deno task test`.
- **`run-issue.mts`** — `docker({ imageName: 'hotsauce-agent' })`, drop `permissionMode`, forward `CLAUDE_CODE_OAUTH_TOKEN` into the container via the agent `env`, and `logging: { type: 'stdout' }` so progress is visible in the Actions log (previously hidden in `.sandcastle/logs/main.log`).
- **workflow** — build the image with host UID/GID (`docker build --build-arg AGENT_UID=$(id -u) …`); remove the now-unneeded runner-side Deno and Claude Code CLI install steps (both live in the image).

## Notes / follow-ups

- First run on a runner pays a one-time image build (~1–2 min); not yet layer-cached across runs — can add buildx cache later if it's slow.
- I can't exercise the live container run from here; verification is the next labelled-issue run. Re-trigger #51 by swapping `agent:blocked` → `agent:explore` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)