### PR TITLE
Agent: Document SameSite auth cookie guidance for CSRF posture (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A schema-driven headless CMS derived from your Drizzle ORM definitions. Define y
 
 - **Single source of truth**: Your Drizzle schema defines database tables, TypeScript types, validation rules, AND CMS fields
 - **Minimal dependencies**: Core stack is `drizzle-orm` + `zod` + `drizzle-zod` + `@std/media-types` (all zero transitive deps)
-- **Secure by default**: CSRF protection, JWT auth, row-level policies, column-level policies, XSS-safe templates
+- **Secure by default**: CSRF protection, JWT auth (`HttpOnly` + `SameSite=Lax` cookies, configurable — see the [Security Guide](SECURITY.md#cookie-samesite--csrf-posture)), row-level policies, column-level policies, XSS-safe templates
 - **Flexible & extensible**: Pluggable auth, custom validation, row & column policies, plugins with Worker isolation
 - **Cross-runtime**: Works in Deno and Node.js — Web Standard `Request`/`Response` everywhere
 - **Database-agnostic**: Works with any Drizzle-supported database (Postgres, MySQL, SQLite)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ HotSauce CMS implements multiple layers of security:
 - **HS256 signing** with HMAC-SHA256
 - **8-hour default token expiry** (configurable)
 - **HttpOnly cookies** to prevent XSS token theft
-- **SameSite=Lax** to prevent CSRF attacks
+- **SameSite=Lax** to prevent CSRF attacks (configurable — see [Cookie SameSite & CSRF posture](#cookie-samesite--csrf-posture))
 - **Secure flag** automatically set for HTTPS connections
 - **Clock skew tolerance** (60 seconds) for distributed systems
 
@@ -24,6 +24,59 @@ const jwtSecret = crypto.randomUUID() + crypto.randomUUID();
 // ❌ Don't use weak secrets
 const jwtSecret = 'secret123';
 ```
+
+#### Cookie SameSite & CSRF posture
+
+The auth cookie's `SameSite` attribute is the first line of CSRF defense: it
+tells the browser when to attach the cookie to requests that originate from
+other sites. HotSauce defaults to **`SameSite=Lax`** and lets you opt into
+`Strict` via `auth.sameSite`.
+
+```typescript
+createCmsHandler({
+  db,
+  schema,
+  auth: {
+    provider,
+    sameSite: 'Strict', // default is 'Lax'
+  },
+  policies,
+});
+```
+
+**Why `Lax` is the default:**
+
+- It blocks the cookie on cross-site **subrequests** (e.g. a hidden form or
+  `fetch` from an attacker's page), which is the CSRF vector that matters.
+- It still sends the cookie on top-level cross-site **navigation** (clicking a
+  link into an admin page), so deep links and bookmarks keep working while the
+  user stays logged in.
+
+**When `Strict` is appropriate:** `Strict` never sends the cookie on _any_
+cross-site request, including top-level navigation. That is the strongest
+posture, but it has a real UX cost — a user who follows an external link to the
+admin (from email, chat, another app) arrives **logged out** until they
+navigate same-site, because the browser withholds the cookie on that first
+request. Choose `Strict` when the admin is never reached via cross-site links
+and you want the tightest CSRF boundary; otherwise `Lax` is the better default.
+
+`SameSite=None` is intentionally **not** offered: it disables SameSite CSRF
+protection entirely and only makes sense for cross-site embedding, which the
+admin UI does not require.
+
+> **SameSite is not a complete CSRF defense.** It is a browser heuristic, not a
+> guarantee (older browsers and some edge cases ignore it). HotSauce also issues
+> HMAC-signed [CSRF tokens](#2-csrf-protection) on every state-changing request
+> and makes logout POST-only — `SameSite` is defense-in-depth on top of those.
+
+**Deployment caveat (reverse proxies & `Secure`):** `SameSite` is only
+meaningfully protective alongside the `Secure` flag, which HotSauce adds
+automatically when the request is HTTPS. Behind a TLS-terminating proxy the
+origin sees plain HTTP, so HotSauce inspects the `X-Forwarded-Proto` header (via
+`isSecureRequest()` in `packages/auth/cookies.ts`) to detect the original
+scheme. Ensure your proxy sets `X-Forwarded-Proto: https`, otherwise the
+`Secure` flag is omitted and the cookie can leak over HTTP. See
+[Production Deployment → HTTPS](#https).
 
 ### 2. CSRF Protection
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -134,14 +134,18 @@ Tokens expire after 5 minutes by default.
 
 Cookie utilities for JWT-based authentication.
 
-| Export                                   | Purpose                           |
-| ---------------------------------------- | --------------------------------- |
-| `getTokenFromCookies(request, name)`     | Extract JWT from Cookie           |
-| `createAuthCookie(name, token, options)` | Create Set-Cookie header          |
-| `createClearCookie(name, path, secure)`  | Create Set-Cookie to clear cookie |
-| `isSecureRequest(request)`               | Check if request is HTTPS*        |
+| Export                                                           | Purpose                           |
+| ---------------------------------------------------------------- | --------------------------------- |
+| `getTokenFromCookies(request, name)`                             | Extract JWT from Cookie           |
+| `createAuthCookie(name, token, maxAge, path, secure, sameSite?)` | Create Set-Cookie header          |
+| `createClearCookie(name, path, secure, sameSite?)`               | Create Set-Cookie to clear cookie |
+| `isSecureRequest(request)`                                       | Check if request is HTTPS*        |
 
 \* `isSecureRequest` checks both `X-Forwarded-Proto` header (for TLS-terminating proxies) and the URL protocol.
+
+`sameSite` defaults to `'Lax'` and accepts `'Lax' | 'Strict'`. See
+[SECURITY.md → Cookie SameSite & CSRF posture](../../SECURITY.md#cookie-samesite--csrf-posture)
+for when to choose `'Strict'`.
 
 ### Login Page (`login.ts`)
 
@@ -325,7 +329,7 @@ This approach requires no server-side session storage.
 - **HMAC-SHA256** - Industry standard signing
 - **8-hour default expiry** - Configurable
 - **HttpOnly cookies** - XSS protection
-- **SameSite=Lax** - CSRF protection
+- **SameSite=Lax** - CSRF protection (default; configurable to `Strict` — see [SECURITY.md](../../SECURITY.md#cookie-samesite--csrf-posture))
 
 ## Environment Variables
 

--- a/packages/auth/cookies.ts
+++ b/packages/auth/cookies.ts
@@ -2,6 +2,21 @@
 // Shared between auth handlers
 
 /**
+ * SameSite cookie attribute for auth cookies.
+ *
+ * - `Lax` (default): sent on top-level cross-site navigation (e.g. following a
+ *   link into an authed page) but not on cross-site subrequests. Mitigates CSRF
+ *   while preserving normal navigation UX.
+ * - `Strict`: never sent on any cross-site request. Strongest CSRF posture, but
+ *   breaks top-level cross-site navigation into authed pages (an external link
+ *   to the admin lands the user logged-out until they navigate same-site).
+ *
+ * `None` is intentionally not offered: it disables SameSite CSRF protection and
+ * only makes sense for cross-site embedding, which the admin UI does not need.
+ */
+export type SameSite = 'Lax' | 'Strict';
+
+/**
  * Parse JWT token from Cookie header
  *
  * @param request - HTTP request
@@ -35,6 +50,7 @@ export function getTokenFromCookies(
  * @param maxAge - Cookie lifetime in seconds
  * @param path - Cookie path (typically basePath)
  * @param isSecure - Whether to add Secure flag (HTTPS only)
+ * @param sameSite - SameSite attribute (default: 'Lax')
  * @returns Set-Cookie header value
  */
 export function createAuthCookie(
@@ -43,13 +59,14 @@ export function createAuthCookie(
   maxAge: number,
   path: string,
   isSecure: boolean,
+  sameSite: SameSite = 'Lax',
 ): string {
   const parts = [
     `${cookieName}=${token}`,
     `Path=${path}`,
     `Max-Age=${maxAge}`,
     'HttpOnly',
-    'SameSite=Lax',
+    `SameSite=${sameSite}`,
   ];
   if (isSecure) {
     parts.push('Secure');
@@ -63,19 +80,21 @@ export function createAuthCookie(
  * @param cookieName - Cookie name to clear
  * @param path - Cookie path
  * @param isSecure - Whether to add Secure flag (must match original cookie)
+ * @param sameSite - SameSite attribute (default: 'Lax'; should match original)
  * @returns Set-Cookie header value that expires the cookie
  */
 export function createClearCookie(
   cookieName: string,
   path: string,
   isSecure: boolean,
+  sameSite: SameSite = 'Lax',
 ): string {
   const parts = [
     `${cookieName}=`,
     `Path=${path}`,
     'Max-Age=0',
     'HttpOnly',
-    'SameSite=Lax',
+    `SameSite=${sameSite}`,
   ];
   if (isSecure) {
     parts.push('Secure');

--- a/packages/auth/mod.ts
+++ b/packages/auth/mod.ts
@@ -58,6 +58,7 @@ export {
   getTokenFromCookies,
   isSecureRequest,
 } from './cookies.ts';
+export type { SameSite } from './cookies.ts';
 
 // ─────────────────────────────────────────────────────────────
 // Login UI - Login page rendering and styles

--- a/packages/auth/tests/cookies_test.ts
+++ b/packages/auth/tests/cookies_test.ts
@@ -121,6 +121,27 @@ Deno.test('createAuthCookie: handles custom paths', () => {
   assertEquals(cookie2.includes('Path=/cms/admin'), true);
 });
 
+Deno.test('createAuthCookie: defaults to SameSite=Lax', () => {
+  const cookie = createAuthCookie('cms_token', 'abc123', 3600, '/admin', false);
+
+  assertEquals(cookie.includes('SameSite=Lax'), true);
+  assertEquals(cookie.includes('SameSite=Strict'), false);
+});
+
+Deno.test('createAuthCookie: honors SameSite=Strict when requested', () => {
+  const cookie = createAuthCookie(
+    'cms_token',
+    'abc123',
+    3600,
+    '/admin',
+    false,
+    'Strict',
+  );
+
+  assertEquals(cookie.includes('SameSite=Strict'), true);
+  assertEquals(cookie.includes('SameSite=Lax'), false);
+});
+
 // ─────────────────────────────────────────────────────────────
 // createClearCookie tests
 // ─────────────────────────────────────────────────────────────
@@ -153,6 +174,21 @@ Deno.test('createClearCookie: sets empty value', () => {
   const parts = cookie.split('; ');
   const namePart = parts.find((p) => p.startsWith('cms_token='));
   assertEquals(namePart, 'cms_token=');
+});
+
+Deno.test('createClearCookie: defaults to SameSite=Lax', () => {
+  const cookie = createClearCookie('cms_token', '/admin', false);
+
+  assertEquals(cookie.includes('SameSite=Lax'), true);
+  assertEquals(cookie.includes('SameSite=Strict'), false);
+});
+
+Deno.test('createClearCookie: honors SameSite=Strict when requested', () => {
+  // Clearing must match the original cookie's SameSite attribute.
+  const cookie = createClearCookie('cms_token', '/admin', false, 'Strict');
+
+  assertEquals(cookie.includes('SameSite=Strict'), true);
+  assertEquals(cookie.includes('SameSite=Lax'), false);
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -1003,18 +1003,18 @@ auth: {
 
 ### Auth Exports
 
-| Export                                  | Purpose                             |
-| --------------------------------------- | ----------------------------------- |
-| `PasswordProvider`                      | Password + optional TOTP auth       |
-| `hashPassword(password)`                | Hash password with PBKDF2-SHA256    |
-| `verifyPassword(password, hash)`        | Verify password against hash        |
-| `signJwt(payload, secret)`              | Sign a JWT token                    |
-| `verifyJwt(token, secret)`              | Verify and decode JWT               |
-| `createJwtPayload(id, role?, maxAge?)`  | Create JWT payload with expiry      |
-| `AuthProvider`                          | Interface for custom auth providers |
-| `getTokenFromCookies(req, name)`        | Parse JWT from cookie header        |
-| `createAuthCookie(...)`                 | Create Set-Cookie header for JWT    |
-| `createClearCookie(name, path, secure)` | Create Set-Cookie to clear JWT      |
+| Export                                                           | Purpose                             |
+| ---------------------------------------------------------------- | ----------------------------------- |
+| `PasswordProvider`                                               | Password + optional TOTP auth       |
+| `hashPassword(password)`                                         | Hash password with PBKDF2-SHA256    |
+| `verifyPassword(password, hash)`                                 | Verify password against hash        |
+| `signJwt(payload, secret)`                                       | Sign a JWT token                    |
+| `verifyJwt(token, secret)`                                       | Verify and decode JWT               |
+| `createJwtPayload(id, role?, maxAge?)`                           | Create JWT payload with expiry      |
+| `AuthProvider`                                                   | Interface for custom auth providers |
+| `getTokenFromCookies(req, name)`                                 | Parse JWT from cookie header        |
+| `createAuthCookie(name, token, maxAge, path, secure, sameSite?)` | Create Set-Cookie header for JWT    |
+| `createClearCookie(name, path, secure, sameSite?)`               | Create Set-Cookie to clear JWT      |
 
 ### Auth Routes
 

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -458,7 +458,7 @@ Notes:
 | ---------------------------------- | ------------------------------------------------- |
 | `generateCsrfToken(secret)`        | Generate HMAC-SHA256 signed token (4-hour expiry) |
 | `validateCsrfToken(token, secret)` | Validate signature and check expiry               |
-| `getCsrfTokenFromFormData(data)`   | Extract `__cms_csrf` field from form                   |
+| `getCsrfTokenFromFormData(data)`   | Extract `__cms_csrf` field from form              |
 | `getCsrfTokenFromHeader(request)`  | Extract `X-CSRF-Token` header from request        |
 
 **Token Format:** `timestamp.random.signature`
@@ -829,15 +829,16 @@ createCmsHandler({
 
 **Auth options** (when `auth` is an object):
 
-| Option               | Type                   | Default         | Description                                                    |
-| -------------------- | ---------------------- | --------------- | -------------------------------------------------------------- |
-| `auth.provider`      | `AuthProvider`         | _(required)_    | Login provider (e.g., `PasswordProvider`)                      |
-| `auth.secret`        | `string`               | env var         | JWT signing secret (32+ chars). Falls back to `CMS_JWT_SECRET` |
-| `auth.maxAge`        | `number`               | `28800` (8hr)   | Token lifetime in seconds                                      |
-| `auth.cookieName`    | `string`               | `'cms_token'`   | Cookie name for JWT                                            |
-| `auth.loginTitle`    | `string`               | `'Admin Login'` | Title shown on login page                                      |
-| `auth.identityLabel` | `string`               | `'Email'`       | Label for identity field on login page                         |
-| `auth.isRevoked`     | `(payload) => boolean` | —               | Check if a token has been revoked                              |
+| Option               | Type                   | Default         | Description                                                                                              |
+| -------------------- | ---------------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `auth.provider`      | `AuthProvider`         | _(required)_    | Login provider (e.g., `PasswordProvider`)                                                                |
+| `auth.secret`        | `string`               | env var         | JWT signing secret (32+ chars). Falls back to `CMS_JWT_SECRET`                                           |
+| `auth.maxAge`        | `number`               | `28800` (8hr)   | Token lifetime in seconds                                                                                |
+| `auth.cookieName`    | `string`               | `'cms_token'`   | Cookie name for JWT                                                                                      |
+| `auth.sameSite`      | `'Lax' \| 'Strict'`    | `'Lax'`         | Cookie SameSite attribute for CSRF posture ([guidance](../../SECURITY.md#cookie-samesite--csrf-posture)) |
+| `auth.loginTitle`    | `string`               | `'Admin Login'` | Title shown on login page                                                                                |
+| `auth.identityLabel` | `string`               | `'Email'`       | Label for identity field on login page                                                                   |
+| `auth.isRevoked`     | `(payload) => boolean` | —               | Check if a token has been revoked                                                                        |
 
 **Policies** (required when `auth` is configured):
 
@@ -990,6 +991,7 @@ auth: {
   
   // Optional
   cookieName: 'cms_token',        // Default: 'cms_token'
+  sameSite: 'Lax',                // Default: 'Lax' ('Strict' for tighter CSRF)
   maxAge: 60 * 60 * 8,            // Default: 8 hours (in seconds)
   loginTitle: 'Admin Login',      // Default: 'Admin Login'
   identityLabel: 'Email',         // Default: 'Email'
@@ -1209,7 +1211,7 @@ class MyCustomProvider implements AuthProvider {
 ### Security Features
 
 - **HttpOnly cookies** - Tokens not accessible via JavaScript (XSS protection)
-- **SameSite=Lax** - CSRF protection for cross-site requests
+- **SameSite=Lax** - CSRF protection for cross-site requests (default; set `auth.sameSite: 'Strict'` for the tightest posture — see [SECURITY.md → Cookie SameSite & CSRF posture](../../SECURITY.md#cookie-samesite--csrf-posture))
 - **Secure flag** - Cookie only sent over HTTPS (in production)
 - **PBKDF2-SHA256** - 600,000 iterations, 16-byte salt, 32-byte key
 - **Constant-time comparison** - Timing attack resistance
@@ -2352,7 +2354,7 @@ auth: {
 | Export                                | Purpose                                         |
 | ------------------------------------- | ----------------------------------------------- |
 | `SOURCE`                              | Constants: `SOURCE.CMS`, `SOURCE.PLUGIN_PREFIX` |
-| `SOURCE_FIELD_NAME`                   | Form field name: `'__cms_source'`                    |
+| `SOURCE_FIELD_NAME`                   | Form field name: `'__cms_source'`               |
 | `pluginSource(name)`                  | Create `'plugin:{name}'` identifier             |
 | `isPluginSource(source)`              | Check if source is a plugin                     |
 | `getPluginName(source)`               | Extract plugin name from source                 |

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -895,6 +895,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
       provider: options.auth.provider,
       maxAge: options.auth.maxAge ?? 8 * 60 * 60, // 8 hours
       cookieName: options.auth.cookieName ?? 'cms_token',
+      sameSite: options.auth.sameSite ?? 'Lax',
       loginTitle: options.auth.loginTitle ?? 'Admin Login',
       identityLabel: options.auth.identityLabel ?? 'Email',
       isRevoked: options.auth.isRevoked,
@@ -1037,6 +1038,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
               resolvedAuth.cookieName,
               opts.basePath,
               isSecureRequest(request),
+              resolvedAuth.sameSite,
             ),
             ...opts.securityHeaders,
           },
@@ -1162,6 +1164,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
               resolvedAuth.maxAge,
               opts.basePath,
               isSecureRequest(request),
+              resolvedAuth.sameSite,
             );
 
             return new Response(null, {
@@ -1284,6 +1287,7 @@ export function createCmsHandler(options: CmsOptions): Handler {
             resolvedAuth.maxAge,
             opts.basePath,
             isSecureRequest(request),
+            resolvedAuth.sameSite,
           );
 
           return new Response(null, {

--- a/packages/cms/tests/dashboard_policy_test.ts
+++ b/packages/cms/tests/dashboard_policy_test.ts
@@ -54,6 +54,7 @@ function buildDashboardContext(
         provider: {} as never, // Not needed for dashboard
         maxAge: 3600,
         cookieName: 'cms_token',
+        sameSite: 'Lax',
         loginTitle: 'Login',
         identityLabel: 'Email',
       }
@@ -110,6 +111,7 @@ function buildListContext(
         provider: {} as never,
         maxAge: 3600,
         cookieName: 'cms_token',
+        sameSite: 'Lax',
         loginTitle: 'Login',
         identityLabel: 'Email',
       }

--- a/packages/cms/tests/integration_auth_test.ts
+++ b/packages/cms/tests/integration_auth_test.ts
@@ -126,6 +126,59 @@ Deno.test('integration: JWT auth tests', async (t) => {
     assertExists(setCookie, 'Set-Cookie header should be present');
     assertStringIncludes(setCookie, 'cms_token=');
     assertStringIncludes(setCookie, 'HttpOnly');
+    // Auth cookie defaults to SameSite=Lax for CSRF posture.
+    assertStringIncludes(setCookie, 'SameSite=Lax');
+  });
+
+  await t.step('login honors configured auth.sameSite=Strict', async () => {
+    await resetDb();
+
+    const passwordHash = await hashPassword('admin123');
+    await db.insert(adminUsers).values({
+      email: 'admin@example.com',
+      passwordHash,
+      role: 'admin',
+    });
+
+    const handler = createAuthHandler({
+      auth: {
+        secret: AUTH_SECRET,
+        sameSite: 'Strict',
+        provider: new PasswordProvider({
+          db,
+          usersTable: adminUsers,
+          identityColumn: 'email',
+          passwordColumn: 'passwordHash',
+          roleColumn: 'role',
+        }),
+      },
+    });
+
+    // Get CSRF token from login page
+    const loginPageRes = await handler(
+      new Request('http://localhost/admin/login'),
+    );
+    const loginHtml = await loginPageRes.text();
+    const csrfMatch = loginHtml.match(/name="__cms_csrf" value="([^"]+)"/);
+    assertExists(csrfMatch, 'CSRF token should be in login page');
+
+    const formData = createFormData({
+      identity: 'admin@example.com',
+      password: 'admin123',
+      __cms_csrf: csrfMatch[1]!,
+    });
+
+    const loginRes = await handler(
+      new Request('http://localhost/admin/login', {
+        method: 'POST',
+        body: formData,
+      }),
+    );
+
+    assertEquals(loginRes.status, 302);
+    const setCookie = loginRes.headers.get('Set-Cookie');
+    assertExists(setCookie, 'Set-Cookie header should be present');
+    assertStringIncludes(setCookie, 'SameSite=Strict');
   });
 
   await t.step('rejects invalid password', async () => {

--- a/packages/cms/tests/integration_policy_test.ts
+++ b/packages/cms/tests/integration_policy_test.ts
@@ -853,6 +853,7 @@ Deno.test({
             provider: new PasswordProvider({ db, usersTable: adminUsers }),
             maxAge: 3600,
             cookieName: 'cms_token',
+            sameSite: 'Lax',
             loginTitle: 'Login',
             identityLabel: 'Email',
           },

--- a/packages/cms/types.ts
+++ b/packages/cms/types.ts
@@ -1,7 +1,7 @@
 // Handler types and options
 
 import type { IntrospectedSchema, IntrospectedTable } from '@hotsauce/core';
-import type { AuthProvider, JwtPayload } from '@hotsauce/auth';
+import type { AuthProvider, JwtPayload, SameSite } from '@hotsauce/auth';
 import type { Policies } from './policies/types.ts';
 import type { PluginConfig, PluginErrorContext } from './plugins/types.ts';
 import type { PluginRegistry } from './plugins/registry.ts';
@@ -565,6 +565,18 @@ export interface CmsAuthOptions {
   /** Cookie name for JWT (default: 'cms_token') */
   cookieName?: string;
 
+  /**
+   * SameSite attribute for the auth cookie (default: 'Lax').
+   *
+   * - `'Lax'` mitigates CSRF while preserving top-level cross-site navigation
+   *   into authed pages.
+   * - `'Strict'` is the strongest CSRF posture but logs users out when they
+   *   arrive via a cross-site link until they navigate same-site.
+   *
+   * See SECURITY.md → "Cookie SameSite & CSRF posture" for guidance.
+   */
+  sameSite?: SameSite;
+
   /** Title shown on login page (default: 'Admin Login') */
   loginTitle?: string;
 
@@ -621,6 +633,7 @@ export interface ResolvedAuthOptions {
   provider: AuthProvider;
   maxAge: number;
   cookieName: string;
+  sameSite: SameSite;
   loginTitle: string;
   identityLabel: string;
   isRevoked?: (payload: JwtPayload) => Promise<boolean> | boolean;

--- a/packages/cms/validation.ts
+++ b/packages/cms/validation.ts
@@ -46,6 +46,7 @@ const AuthConfigSchema = z.object({
   }).optional(),
   maxAge: z.number().positive().optional(),
   cookieName: z.string().optional(),
+  sameSite: z.enum(['Lax', 'Strict']).optional(),
   loginTitle: z.string().optional(),
   identityLabel: z.string().optional(),
   isRevoked: z.any().optional(),


### PR DESCRIPTION
Closes #42

Implemented by the agent-on-issue workflow.
