### PR TITLE
Add a review round to agent:implement (Copilot + Claude reviewer)

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -139,9 +139,115 @@ jobs:
             echo "Implemented by the agent-on-issue workflow."
           } > "$body_file"
           pr_url=$(gh pr create --base main --head "$BRANCH" --title "$title" --body-file "$body_file" | tail -n1)
+          # Request Copilot now; it reviews asynchronously, concurrently with the
+          # Claude reviewer below.
           gh pr edit "$pr_url" --add-reviewer @copilot \
             || echo "::warning::Could not request Copilot review (is Copilot code review enabled?)"
           echo "PR_URL=$pr_url" >> "$GITHUB_ENV"
+          echo "PR_NUMBER=$(gh pr view "$pr_url" --json number -q .number)" >> "$GITHUB_ENV"
+
+      # --- Review round: a Claude reviewer + Copilot, then one pass of fixes ---
+
+      # The agent emits structured findings (OUTPUT_DIR/review.json); the workflow
+      # posts them. Runs concurrently with the Copilot request above.
+      - name: Run Claude review agent
+        if: steps.preflight.outputs.refused != 'true' && success()
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: ./.sandcastle/node_modules/.bin/tsx .sandcastle/agent-workflows/review/review.ts
+
+      - name: Post Claude review
+        if: steps.preflight.outputs.refused != 'true' && success()
+        run: |
+          set -euo pipefail
+          review_file="${RUNNER_TEMP}/review.json"
+          if [ ! -s "$review_file" ]; then
+            echo "No review.json produced; skipping."
+            exit 0
+          fi
+          payload="${RUNNER_TEMP}/review-payload.json"
+          jq '{event: "COMMENT", body: .summary,
+               comments: [.comments[] | {path, line, side, body}]}' \
+            "$review_file" > "$payload"
+          gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" -X POST --input "$payload" \
+            || echo "::warning::Could not post Claude review."
+
+      # Copilot reviews asynchronously; poll (bounded) so the fix agent sees its
+      # comments. A timeout is a warning, not a failure.
+      - name: Wait for Copilot review
+        if: steps.preflight.outputs.refused != 'true' && success()
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 600 )) # ~10 min cap, inside the 60 min budget
+          while :; do
+            count=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" \
+              --jq '[.[] | select(.user.login | test("copilot";"i"))] | length' 2>/dev/null || echo 0)
+            if [ "${count:-0}" -gt 0 ]; then
+              echo "Copilot review detected."
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::warning::Copilot review did not arrive within the timeout; proceeding with available comments."
+              break
+            fi
+            sleep 20
+          done
+
+      # Fix agent: fetch all comments (Copilot + Claude), fix + commit, emit
+      # replies (OUTPUT_DIR/replies.json). Exits early if there are no comments.
+      - name: Run address-review agent
+        if: steps.preflight.outputs.refused != 'true' && success()
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: ./.sandcastle/node_modules/.bin/tsx .sandcastle/agent-workflows/address-review/address-review.ts
+
+      # Deterministic gate so a broken fix lands the issue on agent:blocked
+      # rather than relying on the async test.yml run.
+      - name: Run tests after fixes
+        if: steps.preflight.outputs.refused != 'true' && success()
+        run: deno task test
+
+      # Re-push fix commits with the PAT so test.yml re-runs on the PR.
+      - name: Re-push review fixes
+        if: steps.preflight.outputs.refused != 'true' && success()
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          PR_CREATE_TOKEN: ${{ secrets.PR_CREATE_TOKEN }}
+        run: |
+          set -euo pipefail
+          ahead=$(git rev-list --count "origin/${BRANCH}..${BRANCH}")
+          if [ "$ahead" -eq 0 ]; then
+            echo "No new commits from the review round; nothing to re-push."
+            exit 0
+          fi
+          git remote set-url origin "https://x-access-token:${PR_CREATE_TOKEN}@github.com/${GH_REPO}.git"
+          git push origin "$BRANCH"
+
+      - name: Post review replies
+        if: steps.preflight.outputs.refused != 'true' && success()
+        run: |
+          set -euo pipefail
+          replies_file="${RUNNER_TEMP}/replies.json"
+          if [ ! -s "$replies_file" ]; then
+            echo "No replies to post."
+            exit 0
+          fi
+          count=$(jq 'length' "$replies_file")
+          if [ "$count" -eq 0 ]; then
+            echo "No replies to post."
+            exit 0
+          fi
+          for i in $(seq 0 $(( count - 1 ))); do
+            cid=$(jq -r ".[$i].comment_id" "$replies_file")
+            body=$(jq -r ".[$i].body" "$replies_file")
+            gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/comments" \
+              -X POST -f body="$body" -F in_reply_to="$cid" \
+              || echo "::warning::Could not post reply to comment $cid."
+          done
 
       - name: Finalize implement
         if: steps.preflight.outputs.refused != 'true' && success()

--- a/.sandcastle/README.md
+++ b/.sandcastle/README.md
@@ -19,9 +19,17 @@ Workflows (one per action, mirroring sandcastle's `.github/workflows/`):
     │   ├── explore.ts
     │   ├── prompt.md            # produce pass
     │   └── extraction.md        # structured <output> pass
-    └── implement/               # agent:implement — implement on a branch
-        ├── implement.ts
-        └── prompt.md
+    ├── implement/               # agent:implement — implement on a branch
+    │   ├── implement.ts
+    │   └── prompt.md
+    ├── review/                  # review round — read-only Claude reviewer
+    │   ├── review.ts            # emits review.json (inline comments)
+    │   ├── prompt.md
+    │   └── extraction.md
+    └── address-review/          # review round — fix Copilot + Claude comments
+        ├── address-review.ts    # fixes + commits, emits replies.json
+        ├── prompt.md
+        └── extraction.md
 ```
 
 ## State machine
@@ -29,7 +37,7 @@ Workflows (one per action, mirroring sandcastle's `.github/workflows/`):
 | Add this label    | Agent does                                           | On success                                        | On failure                                       |
 | ----------------- | ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
 | `agent:explore`   | Researches the issue read-only, emits triage notes   | −`in-progress`, +`agent:explored`, comments notes | −`in-progress`, +`agent:blocked`, comments error |
-| `agent:implement` | Implements on `agent/issue-<n>`, the workflow PRs it | −`in-progress`, +`agent:done`, comments PR link   | −`in-progress`, +`agent:blocked`, comments error |
+| `agent:implement` | Implements on `agent/issue-<n>`, the workflow PRs it, then runs one **review round** (Copilot + a Claude reviewer) and addresses the comments | −`in-progress`, +`agent:done`, comments PR link   | −`in-progress`, +`agent:blocked`, comments error |
 
 Both add `agent:in-progress` on start. Typical flow: label `agent:explore`,
 review the triage comment, then label `agent:implement`.
@@ -38,16 +46,24 @@ review the triage comment, then label `agent:implement`.
 
 - **`noSandbox()`** — the ephemeral GitHub Actions runner is the sandbox. No
   `permissionMode` is set; headless `claude -p` edits/commits without prompts.
-- **Separation of duties** — the agent only researches (explore) or edits +
-  commits on a pre-created branch (implement). It never pushes, opens PRs, or
-  edits labels. The **workflow** pushes, opens the PR, requests Copilot, and
-  drives labels.
-- **Explore uses structured output** — the agent emits an `<output>{comment}`
-  block (`run-with-extraction.ts`); the script writes it to
-  `OUTPUT_DIR/comment.md` and the workflow posts it.
-- **Branch push uses `GITHUB_TOKEN`; PR creation uses `PR_CREATE_TOKEN`** (a
-  fine-grained PAT, Pull requests: write) so `test.yml` runs on the agent's PR —
-  the built-in token can't trigger downstream workflows.
+- **Separation of duties** — the agents only research (explore), edit + commit
+  on a pre-created branch (implement, address-review), or read + report (review).
+  They never push, open PRs, edit labels, or call the GitHub API. The **workflow**
+  pushes, opens the PR, requests Copilot, posts the Claude review and the review
+  replies, and drives labels.
+- **Structured output everywhere** — agents emit an `<output>` block
+  (`run-with-extraction.ts`) the workflow consumes: explore → `comment.md`;
+  review → `review.json` (inline comments); address-review → `replies.json`
+  (threaded replies). The workflow posts all of it.
+- **Review round (one pass)** — after the PR opens, the workflow requests Copilot
+  (async) and posts the `review/` agent's findings as inline comments, so both
+  reviews land together. It polls (bounded, ~10 min; a timeout is a warning) for
+  Copilot, then runs `address-review/` over **all** comments. If the post-fix
+  `deno task test` fails the issue goes `agent:blocked`; otherwise fixes are
+  re-pushed and replies posted before `agent:done`.
+- **Branch push uses `GITHUB_TOKEN`; PR creation and the re-push of review fixes
+  use `PR_CREATE_TOKEN`** (a fine-grained PAT, Pull requests: write) so `test.yml`
+  runs on the agent's PR — the built-in token can't trigger downstream workflows.
 
 ## One-time setup
 
@@ -74,4 +90,13 @@ npx tsx agent-workflows/explore/explore.ts
 export BRANCH=agent/issue-123
 git switch -c "$BRANCH"
 npx tsx agent-workflows/implement/implement.ts
+
+# review -> read-only; needs a branch with a diff vs main. Writes output/review.json
+export PR_NUMBER=456
+npx tsx agent-workflows/review/review.ts
+
+# address-review -> fetches the PR's review comments, fixes + commits.
+# Writes output/replies.json. Needs GH_REPO=owner/repo and a real PR with comments.
+export GH_REPO=owner/repo
+npx tsx agent-workflows/address-review/address-review.ts
 ```

--- a/.sandcastle/agent-workflows/address-review/address-review.ts
+++ b/.sandcastle/agent-workflows/address-review/address-review.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { noSandbox } from "@ai-hero/sandcastle/sandboxes/no-sandbox";
+import {
+  asArray,
+  asNumber,
+  asRecord,
+  asString,
+  claudeAgent,
+  fail,
+  gh,
+  required,
+  standardSchema,
+  writeJson,
+} from "../shared/common.ts";
+import { runWithExtraction } from "../shared/run-with-extraction.ts";
+
+interface Reply {
+  readonly comment_id: number;
+  readonly body: string;
+}
+
+interface AddressOutput {
+  readonly replies: readonly Reply[];
+}
+
+const addressOutputSchema = standardSchema<AddressOutput>((value) => {
+  const record = asRecord(value, "address-review output");
+  return {
+    replies: asArray(record.replies, "replies", (entry, label) => {
+      const reply = asRecord(entry, label);
+      return {
+        comment_id: asNumber(reply.comment_id, `${label}.comment_id`),
+        body: asString(reply.body, `${label}.body`),
+      };
+    }),
+  };
+});
+
+interface RawComment {
+  readonly id: number;
+  readonly path?: string;
+  readonly line?: number | null;
+  readonly original_line?: number | null;
+  readonly body?: string;
+  readonly diff_hunk?: string;
+  readonly user?: { readonly login?: string };
+}
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+const REPO = required("GH_REPO"); // owner/repo
+
+try {
+  // Fetch every inline review comment (Copilot + the Claude reviewer). gh merges
+  // paginated array responses into one JSON array.
+  const raw = gh([
+    "api",
+    "--paginate",
+    `repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100`,
+  ]);
+  const comments = JSON.parse(raw) as RawComment[];
+
+  if (comments.length === 0) {
+    writeJson("replies.json", []);
+    console.log("No review comments to address — skipping fix agent.");
+    process.exit(0);
+  }
+
+  // Compact view the agent reasons over; keep the fields it needs to locate and
+  // reply to each thread.
+  const commentsForPrompt = comments.map((c) => ({
+    id: c.id,
+    path: c.path,
+    line: c.line ?? c.original_line ?? null,
+    author: c.user?.login,
+    body: c.body,
+    diff_hunk: c.diff_hunk,
+  }));
+
+  const result = await runWithExtraction({
+    name: `address-review-#${PR_NUMBER}`,
+    agent: claudeAgent(),
+    sandbox: noSandbox(),
+    logging: { type: "stdout" },
+    promptFile: path.join(import.meta.dirname!, "prompt.md"),
+    promptArgs: {
+      PR_NUMBER,
+      BRANCH,
+      COMMENTS: JSON.stringify(commentsForPrompt, null, 2),
+    },
+    output: sandcastle.Output.object({
+      tag: "output",
+      schema: addressOutputSchema,
+    }),
+    extractionPrompt: fs.readFileSync(
+      path.join(import.meta.dirname!, "extraction.md"),
+      "utf8",
+    ),
+  });
+
+  writeJson("replies.json", result.output.replies);
+
+  console.log(
+    `Addressed ${comments.length} comment(s); produced ${result.output.replies.length} reply(ies).`,
+  );
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/.sandcastle/agent-workflows/address-review/extraction.md
+++ b/.sandcastle/agent-workflows/address-review/extraction.md
@@ -1,0 +1,24 @@
+Emit a single `<output>` block as the last thing in your response.
+
+Do not change files. Do not run commands. Do not include text outside the
+`<output>` block.
+
+```json
+<output>
+{
+  "replies": [
+    {
+      "comment_id": 123456789,
+      "body": "Fixed in this round: <what changed>. (Or: dismissed because <why>.)"
+    }
+  ]
+}
+</output>
+```
+
+Rules:
+
+- `replies` may be an empty array (`[]`) if there was nothing to respond to.
+- Each `comment_id` must be the `id` of one of the review comments you were
+  given. `body` is non-empty markdown — a short reply for that thread.
+- Include one reply per comment you fixed or dismissed.

--- a/.sandcastle/agent-workflows/address-review/prompt.md
+++ b/.sandcastle/agent-workflows/address-review/prompt.md
@@ -1,0 +1,60 @@
+# TASK
+
+Address the code-review comments on PR #{{PR_NUMBER}}. You are on branch
+`{{BRANCH}}`, already checked out. The comments come from two reviewers (GitHub
+Copilot and a Claude reviewer); treat them the same way.
+
+This runs **headless in CI** — there is no human to ask. Do the work in **one
+round**: make your best judgement on each comment, fix what should be fixed, and
+justify what you dismiss. Do not wait for approval and do not re-review your own
+output.
+
+# REVIEW COMMENTS
+
+Each entry has an `id` (use it as `comment_id` when you reply), `path`, `line`,
+`author`, `body`, and the `diff_hunk` it was left on.
+
+```json
+{{COMMENTS}}
+```
+
+# CONTEXT
+
+Read the project's conventions before changing code:
+
+- `AGENTS.md` (repo conventions — note the ⛔ CRITICAL RULES)
+- package-level `README.md` files where relevant
+
+Explore the surrounding code and tests before editing.
+
+# PROCEDURE
+
+For each comment, decide:
+
+- **Valid + fixable** — implement the fix. Where a test seam already exists, do
+  red-green-refactor (write a failing test, make the smallest correct change).
+  Do not improvise new test seams just to test in isolation.
+- **Invalid / already handled** — do not change code; instead plan a short,
+  polite reply explaining why, with evidence (a line reference or test name).
+
+When several comments touch the same area, group related fixes into one commit.
+
+Run `deno task test` before committing, and make it pass.
+
+# COMMIT
+
+Make one or more commits on `{{BRANCH}}` with conventional commit messages (e.g.
+`fix: …`) that reference the feedback. If every comment was invalid, it is fine
+to make no commits.
+
+Do **not** push the branch. Do **not** close the issue. Do **not** edit labels.
+Do **not** create or edit PRs. Do **not** post comments or replies via the
+GitHub API — the workflow posts your replies for you (see the output step).
+
+# REPLIES
+
+For each comment you acted on or dismissed, produce a reply keyed by its
+`comment_id`, stating what you changed or why it does not apply. The workflow
+posts these to the review threads.
+
+When complete, output `<promise>COMPLETE</promise>`.

--- a/.sandcastle/agent-workflows/review/extraction.md
+++ b/.sandcastle/agent-workflows/review/extraction.md
@@ -1,0 +1,29 @@
+Emit a single `<output>` block as the last thing in your response.
+
+Do not change files. Do not run commands. Do not include text outside the
+`<output>` block.
+
+```json
+<output>
+{
+  "summary": "A short markdown overview of the review (what you checked, overall verdict). Required, non-empty.",
+  "comments": [
+    {
+      "path": "packages/core/src/example.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "The inline review comment for this line."
+    }
+  ]
+}
+</output>
+```
+
+Rules:
+
+- `summary` is required and must be non-empty markdown.
+- `comments` may be an empty array (`[]`) if you found nothing worth flagging.
+- Each comment's `path` must be a file changed in the diff, and `line` must be a
+  line that appears in the diff for that file. Use `"side": "RIGHT"` for added /
+  unchanged lines (the new version) and `"side": "LEFT"` for removed lines.
+- `line` is a number; `body` is non-empty markdown.

--- a/.sandcastle/agent-workflows/review/prompt.md
+++ b/.sandcastle/agent-workflows/review/prompt.md
@@ -1,0 +1,44 @@
+# TASK
+
+You are reviewing the code on PR #{{PR_NUMBER}} (branch `{{BRANCH}}`), a change
+implemented by an automated agent. Review it the way a careful human reviewer
+would: focus on real problems, not style nits a formatter already handles.
+
+# CONTEXT
+
+Read the project's conventions before judging the code:
+
+- `AGENTS.md` (repo conventions for agents — note the ⛔ CRITICAL RULES)
+- package-level `README.md` files where relevant
+
+Explore the surrounding code and tests so your comments are grounded in how the
+codebase actually works.
+
+# DIFF UNDER REVIEW
+
+```diff
+{{DIFF}}
+```
+
+# WHAT TO LOOK FOR
+
+In priority order:
+
+1. **Correctness bugs** — logic errors, wrong edge-case handling, broken
+   invariants, missing `await`, incorrect types, security/permission mistakes.
+2. **Convention violations** — anything that breaks the rules in `AGENTS.md`
+   (e.g. `Deno.*`/Node APIs in packages, unapproved dependencies, `--allow-*`
+   flags, `npm`/`yarn`/`pnpm` usage).
+3. **Clear reuse / simplification** — duplicated logic that an existing helper
+   already covers, or needless complexity with an obviously simpler form.
+
+Only raise something you are confident about and can tie to a specific line.
+Prefer fewer, high-signal comments. If the change looks correct, it is fine to
+return no inline comments.
+
+# CONSTRAINTS
+
+This is a **read-only** review. Do **not** edit files, run tests, commit, push,
+create or edit PRs, or call the GitHub API. Just read and analyse.
+
+When complete, output `<promise>COMPLETE</promise>`.

--- a/.sandcastle/agent-workflows/review/review.ts
+++ b/.sandcastle/agent-workflows/review/review.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { noSandbox } from "@ai-hero/sandcastle/sandboxes/no-sandbox";
+import {
+  asArray,
+  asNumber,
+  asRecord,
+  asString,
+  claudeAgent,
+  fail,
+  required,
+  safeSh,
+  standardSchema,
+  writeJson,
+} from "../shared/common.ts";
+import { runWithExtraction } from "../shared/run-with-extraction.ts";
+
+interface ReviewComment {
+  readonly path: string;
+  readonly line: number;
+  readonly side: "LEFT" | "RIGHT";
+  readonly body: string;
+}
+
+interface ReviewOutput {
+  readonly summary: string;
+  readonly comments: readonly ReviewComment[];
+}
+
+const reviewOutputSchema = standardSchema<ReviewOutput>((value) => {
+  const record = asRecord(value, "review output");
+  return {
+    summary: asString(record.summary, "summary"),
+    comments: asArray(record.comments, "comments", (entry, label) => {
+      const comment = asRecord(entry, label);
+      const side = asString(comment.side, `${label}.side`).toUpperCase();
+      if (side !== "LEFT" && side !== "RIGHT") {
+        throw new Error(`${label}.side must be "LEFT" or "RIGHT"`);
+      }
+      return {
+        path: asString(comment.path, `${label}.path`),
+        line: asNumber(comment.line, `${label}.line`),
+        side,
+        body: asString(comment.body, `${label}.body`),
+      };
+    }),
+  };
+});
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+
+try {
+  // The diff under review. `git diff main...HEAD` (three-dot) compares against
+  // the merge base, matching what the PR shows.
+  const diff = safeSh("git diff main...HEAD") ||
+    safeSh(`gh pr diff ${PR_NUMBER}`);
+  if (!diff.trim()) {
+    fail("No diff to review (main...HEAD is empty).");
+  }
+
+  const result = await runWithExtraction({
+    name: `review-#${PR_NUMBER}`,
+    agent: claudeAgent(),
+    sandbox: noSandbox(),
+    logging: { type: "stdout" },
+    promptFile: path.join(import.meta.dirname!, "prompt.md"),
+    promptArgs: {
+      PR_NUMBER,
+      BRANCH,
+      DIFF: diff,
+    },
+    output: sandcastle.Output.object({
+      tag: "output",
+      schema: reviewOutputSchema,
+    }),
+    extractionPrompt: fs.readFileSync(
+      path.join(import.meta.dirname!, "extraction.md"),
+      "utf8",
+    ),
+  });
+
+  writeJson("review.json", result.output);
+
+  console.log(
+    `Review produced ${result.output.comments.length} inline comment(s) for PR #${PR_NUMBER}.`,
+  );
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/.sandcastle/agent-workflows/shared/common.ts
+++ b/.sandcastle/agent-workflows/shared/common.ts
@@ -101,3 +101,21 @@ export const asString = (value: unknown, label: string): string => {
   }
   return value;
 };
+
+export const asNumber = (value: unknown, label: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  return value;
+};
+
+export const asArray = <T>(
+  value: unknown,
+  label: string,
+  item: (value: unknown, label: string) => T,
+): readonly T[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value.map((entry, index) => item(entry, `${label}[${index}]`));
+};


### PR DESCRIPTION
Closes #77

## What

Adds one **review round** to the `agent:implement` workflow. After the PR opens, the workflow requests **GitHub Copilot** and a **separate Claude reviewer** concurrently, then addresses **both** sets of comments in a single round before finalizing.

## How it works

After "Open PR" and before "Finalize":

1. **Post Claude review** — a read-only `review/` agent diffs `main...HEAD` and emits `review.json`; the workflow posts it as inline PR comments. Copilot was already requested at PR-open, so both reviews land together.
2. **Wait for Copilot** — bounded poll (~20s × ~10 min cap). A timeout is a `::warning::`, not a failure (graceful skip).
3. **Address review** — an `address-review/` agent fetches **all** inline comments (Copilot + Claude) via paginated `pulls/{n}/comments`, fixes them, runs `deno task test`, and commits; it emits `replies.json`.
4. **Test gate** — `deno task test` runs as an explicit step so a broken fix lands the issue on `agent:blocked` rather than relying on the async `test.yml`.
5. **Re-push** fix commits with `PR_CREATE_TOKEN` (re-triggers `test.yml`).
6. **Post replies** to each thread via `in_reply_to`.
7. **Finalize** (`agent:done`) only after the round.

## New agents (mirror `explore/` + `implement/`)

- `.sandcastle/agent-workflows/review/` — read-only reviewer → `review.json`.
- `.sandcastle/agent-workflows/address-review/` — CI-adapted fix agent → commits + `replies.json`. Its prompt overrides the interactive gates in `pr-review/SKILL.md` ("wait for user", "never auto-reply") for headless, one-round operation.
- `shared/common.ts` — added `asNumber` / `asArray` validators.

## Separation of duties

Consistent with the existing invariant: agents only review or edit+commit and emit **structured output**; the **workflow** performs every GitHub mutation (posting the review, replies, push, labels).

## Decisions

Inline-in-job · inline PR review comments · `agent:blocked` on fix/test failure · threaded replies + push. Copilot wait defaulted to ~20s/10 min (adjustable).

## Verification

- `tsc --strict` (nodenext) on the new files: clean.
- Workflow YAML parses; review steps ordered before Finalize.
- `.sandcastle/` is excluded from Deno fmt/lint/check; new files lint clean on their own.
- End-to-end (live run, forced-failure → `agent:blocked`, and Copilot-disabled graceful skip) need real secrets + a throwaway issue and are best exercised against this PR.

> Note: the fix round consumes Copilot's **inline** comments; a Copilot top-level summary with no inline comments is not fed to the fix agent (matches the "inline PR review comments" decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)