### PR TITLE
Add CMS CRUD benchmarks as a PR check (#81)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,102 @@
+name: Benchmark
+
+# Same-run A/B benchmark of the CMS's critical request->response CRUD path.
+# The PR's benchmark files are run twice on the same runner: once against the
+# PR's package source, once against the base branch's package source. Running
+# back-to-back on one machine cancels most runner timing variance.
+#
+# Deliberately kept SEPARATE from test.yml (the required merge gate) so a flaky
+# timing comparison can never block merges on its own. A regression must
+# reproduce on a confirmation run before the check fails.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Regression threshold: a benchmark must be more than this % slower than the
+# base branch to count as a regression.
+env:
+  THRESHOLD: '10'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            .deno_cache
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
+      - name: Run benchmarks (A/B) and compare
+        id: bench
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -e
+          git fetch origin "$BASE_REF"
+
+          # Run one A/B pass: bench PR source, then bench base-branch package
+          # source using the PR's (identical) benchmark files. Writes the
+          # markdown report to $1 and returns compare.ts's exit code.
+          run_ab() {
+            local out="$1"
+            deno bench -P --json benchmarks/ > pr.json
+            git checkout FETCH_HEAD -- packages
+            deno bench -P --json benchmarks/ > main.json
+            git checkout HEAD -- packages
+            set +e
+            deno run --allow-read benchmarks/compare.ts main.json pr.json "$THRESHOLD" > "$out"
+            local code=$?
+            set -e
+            return $code
+          }
+
+          fail=false
+          run_ab report.md && first=0 || first=$?
+          if [ "${first:-0}" -ne 0 ]; then
+            echo "Regression flagged on first pass — re-running to confirm..."
+            run_ab report.md && second=0 || second=$?
+            if [ "${second:-0}" -ne 0 ]; then
+              fail=true
+              printf '\n_Regression reproduced on a confirmation run._\n' >> report.md
+            else
+              printf '\n_First pass flagged a regression but it did not reproduce on a confirmation run — treating as runner noise._\n' >> report.md
+            fi
+          fi
+
+          echo "fail=$fail" >> "$GITHUB_OUTPUT"
+          cat report.md
+
+      # New comment each run (no sticky/update-in-place). Skip fork PRs, whose
+      # GITHUB_TOKEN is read-only and cannot comment.
+      - name: Comment results on PR
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('report.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body-file report.md
+
+      - name: Fail on confirmed regression
+        if: steps.bench.outputs.fail == 'true'
+        run: |
+          echo "::error::Confirmed performance regression vs ${{ github.base_ref }} (> ${THRESHOLD}% slower)."
+          exit 1

--- a/benchmarks/cms_bench.ts
+++ b/benchmarks/cms_bench.ts
@@ -1,0 +1,194 @@
+// Benchmarks for the CMS's critical user-facing path: the full
+// request -> response CRUD flow through `createCmsHandler(options)(request)`.
+//
+// Each case is benchmarked against both supported driver families:
+//   - PGlite   (Postgres dialect)
+//   - sql.js   (SQLite dialect)
+//
+// Benchmark names are stable ("<driver>: <case>") so benchmarks/compare.ts can
+// match the same case across two `deno bench --json` runs (PR vs main).
+//
+// These files live outside packages/*/, so `Deno.bench` / `Deno.*` usage is
+// allowed here (the runtime-agnostic rule only applies to shipped package code).
+
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle as drizzlePglite } from 'drizzle-orm/pglite';
+import { drizzle as drizzleSqlJs } from 'drizzle-orm/sql-js';
+import initSqlJs from 'sql.js';
+import { sql } from 'drizzle-orm';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+// Patches Drizzle prototypes (.$cms etc.) — imported for side effects.
+import '@hotsauce/core/extend';
+import { createCmsHandler } from '@hotsauce/cms';
+import { generateCsrfToken } from '../packages/cms/csrf.ts';
+import {
+  createBasicTables,
+  createFormData,
+  generateSourceToken,
+  schema as pgSchema,
+  SOURCE,
+  TEST_CSRF_SECRET,
+  users as pgUsers,
+} from '../packages/cms/tests/integration_helpers.ts';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PATH = '/admin';
+const SEED_USERS = 10;
+
+// CSRF + source tokens are stateless, signed, and valid for 4 hours, so we
+// generate them once and reuse them across the create iterations.
+const csrfToken = await generateCsrfToken(TEST_CSRF_SECRET);
+const sourceToken = await generateSourceToken(SOURCE.CMS, TEST_CSRF_SECRET);
+
+// deno-lint-ignore no-explicit-any
+function buildHandler(db: any, schema: any) {
+  return createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema,
+    basePath: BASE_PATH,
+  });
+}
+
+function createRequest(): Request {
+  return new Request(`http://localhost${BASE_PATH}/users`);
+}
+
+function readRequest(): Request {
+  return new Request(`http://localhost${BASE_PATH}/users/1`);
+}
+
+// Each create needs a unique email (UNIQUE constraint). Counter keeps it cheap.
+let createCounter = 0;
+function newUserRequest(): Request {
+  createCounter += 1;
+  const formData = createFormData({
+    __cms_csrf: csrfToken,
+    __cms_source: sourceToken,
+    email: `bench-${createCounter}@example.com`,
+    name: `Bench User ${createCounter}`,
+    bio: 'created during benchmarking',
+  });
+  return new Request(`http://localhost${BASE_PATH}/users/new`, {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PGlite (Postgres) setup
+// ---------------------------------------------------------------------------
+
+const pgClient = new PGlite();
+const pgDb = drizzlePglite(pgClient, { schema: pgSchema });
+await createBasicTables(pgDb);
+await pgDb.insert(pgUsers).values(
+  Array.from({ length: SEED_USERS }, (_, i) => ({
+    email: `seed-${i}@example.com`,
+    name: `Seed User ${i}`,
+    bio: 'seed row',
+  })),
+);
+const pgHandler = buildHandler(pgDb, pgSchema);
+
+// ---------------------------------------------------------------------------
+// sql.js (SQLite) setup
+// ---------------------------------------------------------------------------
+
+const sqliteUsers = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull(),
+  bio: text('bio'),
+  isAdmin: integer('is_admin', { mode: 'boolean' }).notNull().default(false),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+});
+
+const sqlitePosts = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  body: text('body'),
+  authorId: integer('author_id').notNull().references(() => sqliteUsers.id),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+});
+
+const sqliteSchema = { users: sqliteUsers, posts: sqlitePosts };
+
+const SQL = await initSqlJs();
+const sqliteClient = new SQL.Database();
+const sqliteDb = drizzleSqlJs(sqliteClient, { schema: sqliteSchema });
+
+sqliteDb.run(sql`
+  CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    bio TEXT,
+    is_admin INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  )
+`);
+sqliteDb.run(sql`
+  CREATE TABLE posts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    body TEXT,
+    author_id INTEGER NOT NULL REFERENCES users(id),
+    created_at INTEGER NOT NULL
+  )
+`);
+await sqliteDb.insert(sqliteUsers).values(
+  Array.from({ length: SEED_USERS }, (_, i) => ({
+    email: `seed-${i}@example.com`,
+    name: `Seed User ${i}`,
+    bio: 'seed row',
+  })),
+);
+const sqliteHandler = buildHandler(sqliteDb, sqliteSchema);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+//
+// Ordered list -> read -> create per driver so the row-growing create case runs
+// last and does not skew the list/read cases.
+// ---------------------------------------------------------------------------
+
+Deno.bench('pglite: list users', { group: 'list users' }, async () => {
+  const res = await pgHandler(createRequest());
+  await res.text();
+});
+
+Deno.bench('sqlite: list users', { group: 'list users' }, async () => {
+  const res = await sqliteHandler(createRequest());
+  await res.text();
+});
+
+Deno.bench('pglite: read user', { group: 'read user' }, async () => {
+  const res = await pgHandler(readRequest());
+  await res.text();
+});
+
+Deno.bench('sqlite: read user', { group: 'read user' }, async () => {
+  const res = await sqliteHandler(readRequest());
+  await res.text();
+});
+
+Deno.bench('pglite: create user', { group: 'create user' }, async () => {
+  const res = await pgHandler(newUserRequest());
+  await res.body?.cancel();
+});
+
+Deno.bench('sqlite: create user', { group: 'create user' }, async () => {
+  const res = await sqliteHandler(newUserRequest());
+  await res.body?.cancel();
+});

--- a/benchmarks/compare.ts
+++ b/benchmarks/compare.ts
@@ -1,0 +1,135 @@
+// Compares two `deno bench --json` outputs (baseline = main, current = PR) and
+// renders a compact markdown table of the per-benchmark deltas.
+//
+// Usage:
+//   deno run --allow-read benchmarks/compare.ts <baseline.json> <current.json> [thresholdPct]
+//
+// - Prints the markdown table to stdout (captured by the benchmark workflow and
+//   posted as a PR comment).
+// - Exits non-zero if any benchmark is more than `thresholdPct` slower than the
+//   baseline. The workflow uses this both to flag regressions and to gate a
+//   confirmation re-run before failing the check.
+
+interface BenchResult {
+  ok?: { avg: number };
+  failed?: unknown;
+}
+
+interface Bench {
+  name: string;
+  group?: string;
+  results: BenchResult[];
+}
+
+interface BenchFile {
+  benches: Bench[];
+}
+
+const DEFAULT_THRESHOLD_PCT = 10;
+
+const encoder = new TextEncoder();
+function writeLine(stream: typeof Deno.stdout | typeof Deno.stderr, s: string) {
+  stream.writeSync(encoder.encode(s + '\n'));
+}
+
+function avgFor(bench: Bench): number | null {
+  const ok = bench.results.find((r) => r.ok)?.ok;
+  return ok ? ok.avg : null;
+}
+
+// Nanoseconds -> human-readable string, matching deno bench's own units.
+function formatTime(ns: number): string {
+  if (ns < 1_000) return `${ns.toFixed(1)} ns`;
+  if (ns < 1_000_000) return `${(ns / 1_000).toFixed(1)} µs`;
+  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)} ms`;
+  return `${(ns / 1_000_000_000).toFixed(2)} s`;
+}
+
+async function readBenches(path: string): Promise<Map<string, number>> {
+  const data = JSON.parse(await Deno.readTextFile(path)) as BenchFile;
+  const map = new Map<string, number>();
+  for (const bench of data.benches ?? []) {
+    const avg = avgFor(bench);
+    if (avg !== null) map.set(bench.name, avg);
+  }
+  return map;
+}
+
+async function run(args: string[]): Promise<number> {
+  const [baselinePath, currentPath, thresholdArg] = args;
+  if (!baselinePath || !currentPath) {
+    writeLine(
+      Deno.stderr,
+      'Usage: compare.ts <baseline.json> <current.json> [thresholdPct]',
+    );
+    return 2;
+  }
+  const threshold = thresholdArg !== undefined
+    ? Number(thresholdArg)
+    : DEFAULT_THRESHOLD_PCT;
+
+  const [baseline, current] = await Promise.all([
+    readBenches(baselinePath),
+    readBenches(currentPath),
+  ]);
+
+  // Stable ordering: baseline order first, then any current-only benches.
+  const names = [
+    ...baseline.keys(),
+    ...[...current.keys()].filter((n) => !baseline.has(n)),
+  ];
+
+  const rows: string[] = [];
+  const regressions: string[] = [];
+
+  for (const name of names) {
+    const base = baseline.get(name);
+    const cur = current.get(name);
+
+    if (base === undefined) {
+      rows.push(`| ${name} | — | ${formatTime(cur!)} | new |`);
+      continue;
+    }
+    if (cur === undefined) {
+      rows.push(`| ${name} | ${formatTime(base)} | — | removed |`);
+      continue;
+    }
+
+    const pct = ((cur - base) / base) * 100;
+    const sign = pct >= 0 ? '+' : '';
+    const regressed = pct > threshold;
+    const marker = regressed ? ' ⚠️' : '';
+    rows.push(
+      `| ${name} | ${formatTime(base)} | ${formatTime(cur)} | ${sign}${
+        pct.toFixed(1)
+      }%${marker} |`,
+    );
+    if (regressed) {
+      regressions.push(`${name} (${sign}${pct.toFixed(1)}%)`);
+    }
+  }
+
+  const lines = [
+    '### Benchmark results',
+    '',
+    `Comparing PR against \`main\` (same runner). Regression threshold: **${threshold}%** slower.`,
+    '',
+    '| Benchmark | main | PR | Δ |',
+    '| --- | --- | --- | --- |',
+    ...rows,
+    '',
+  ];
+
+  if (regressions.length > 0) {
+    lines.push(`⚠️ **Possible regression:** ${regressions.join(', ')}`);
+  } else {
+    lines.push('✅ No regressions over threshold.');
+  }
+
+  writeLine(Deno.stdout, lines.join('\n'));
+  return regressions.length > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await run(Deno.args));
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -60,6 +60,8 @@
     "test:watch": "deno test -P --watch",
     "test:drizzle-compat": "deno test -P packages/core/tests/drizzle_compat_test.ts",
     "test:npm": "./scripts/npm/test-npm.sh", // builds + tests in Docker
+    // Benchmarking (critical CMS paths — see benchmarks/)
+    "bench": "deno bench -P benchmarks/",
     // Code quality tasks
     "check": "deno check packages/*/mod.ts",
     "lint": "deno lint",
@@ -87,6 +89,26 @@
   // Test configuration with fine-grained permissions
   "test": {
     "include": ["packages/*/tests/"],
+    "permissions": {
+      "read": [
+        "./packages",
+        "./node_modules/.deno/@electric-sql+pglite@0.3.15/node_modules/@electric-sql/pglite/dist/pglite.data",
+        "./node_modules/.deno/@electric-sql+pglite@0.3.15/node_modules/@electric-sql/pglite/dist/pglite.wasm",
+        "./node_modules/.deno/sql.js@1.13.0/node_modules/sql.js/dist/sql-wasm.wasm"
+      ],
+      "env": [
+        "CMS_2FA_SECRET",
+        "CMS_CSRF_SECRET",
+        "CMS_JWT_SECRET",
+        "CMS_TESTING"
+      ]
+    }
+  },
+
+  // Benchmark configuration — mirrors test.permissions.
+  // Benchmark files live outside packages/*/ so Deno.bench/Deno.* is allowed here.
+  "bench": {
+    "include": ["benchmarks/"],
     "permissions": {
       "read": [
         "./packages",


### PR DESCRIPTION
Closes #81.

Adds a benchmark suite for the CMS's critical user-facing path and wires it into a new PR check.

## What
- **`benchmarks/cms_bench.ts`** — `Deno.bench` cases for the full request→response CRUD path through `createCmsHandler(options)(request)` (list / read / create), run against **both** driver families: PGlite (Postgres) and sql.js (SQLite). Reuses the existing integration test harness patterns (`integration_helpers.ts`, the sql.js setup from `core/tests/integration_test.ts`).
- **`benchmarks/compare.ts`** — diffs two `deno bench --json` runs (base vs PR), renders a compact markdown table, and exits non-zero when a benchmark is more than the threshold (default 10%) slower than base.
- **`.github/workflows/benchmark.yml`** — **same-run A/B**: runs the PR's benchmark files twice on one runner — once against PR package source, once against the base branch's `packages/` — to cancel runner timing variance. If a regression is flagged, it **re-runs to confirm** and fails the check only if the regression reproduces. Posts a **new comment each push**. Deliberately separate from `test.yml` so timing noise can never block the required merge gate.
- **`deno.jsonc`** — adds a `bench` task and a `bench` permissions block mirroring `test` (no `--allow-*` flags, no new dependencies — `Deno.bench` is built in).

## Design decisions
Per the issue discussion: full-CRUD path via `createCmsHandler`, both sql.js + PGlite drivers, same-run A/B, new-comment-each-push, fork PRs ignored. Regression policy: confirm with a re-run, then fail if reproduced.

## Verification
- `deno task bench` runs both drivers cleanly (no permission prompts).
- `deno fmt`/`deno lint`/`deno task check` clean for the new files; full `deno task test` green (1267 passed).
- `compare.ts` exercised against captured JSON: exit 0 with no regression, exit 1 on a synthetic regression.
- Simulated the workflow's base-`packages/` swap locally — benches run against base source and the working tree restores cleanly.

> Note: the prior `agent:implement` run failed only at the **Push branch** step — the default `GITHUB_TOKEN` (a GitHub App) cannot create files under `.github/workflows/` without the `workflows` permission. This PR was pushed manually for that reason; the agent pipeline itself is intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)