### PR TITLE
PR #85 follow-ups: s3 correctness, dispatch-owned stream cancellation, s3 npm build (issue #89)

### DIFF
--- a/.github/workflows/node-compat.yml
+++ b/.github/workflows/node-compat.yml
@@ -45,6 +45,7 @@ jobs:
           cp -r npm/auth npm-tests/packages/
           cp -r npm/cms npm-tests/packages/
           cp -r npm/plugins-fs-storage npm-tests/packages/
+          cp -r npm/plugins-s3-storage npm-tests/packages/
 
       - name: Install test dependencies
         working-directory: npm-tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -298,6 +298,34 @@ createFsStoragePlugin({
   serves bytes without the CMS row/column policy checks the `/files/` route
   enforces.
 
+### 10. Object Storage (s3-storage plugin)
+
+The S3 plugin serves downloads two ways, with different exposure:
+
+- **Presigned URLs (default)** — each download is a SigV4-signed URL that
+  expires (`expirySeconds`, default 15 min). The `/files/` route enforces
+  row/column policy before issuing one, and the short lifetime bounds the
+  damage of a leaked link.
+- **CDN URLs (`cdnBaseUrl`)** — `${cdnBaseUrl}/${key}`, **unsigned and
+  non-expiring**. Faster and cache-friendly, but the URL is permanent and
+  guessable, so once issued it bypasses CMS policy on every later fetch.
+
+**Best Practices:**
+
+- Use `cdnBaseUrl` for objects that are safe to serve publicly (published
+  media, avatars). For access-controlled files, either keep the presigned
+  default, or put the CDN behind access control it enforces itself — e.g.
+  **signed cookies** scoped to the session (CloudFront/Cloudflare) or a private
+  distribution. The plugin emits a **bare** URL, so a CDN that requires
+  per-request **signed URLs** (rather than cookies) is not supported by this
+  option.
+- A CDN gated by signed cookies enforces access at the CDN's granularity
+  (typically path or session), which is **coarser** than the CMS's per-record
+  row/column policy — size the cookie scope accordingly.
+- Configure SVG / scriptable-file handling at the bucket/CDN (see the
+  [s3-storage README](packages/plugins/s3-storage/README.md#svg-and-scriptable-files))
+  so a stored `.svg` can't execute scripts in a victim's origin.
+
 ## Environment Variables
 
 ### Required Secrets

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -249,6 +249,50 @@ const policies = {
 - Combine with row policies for defense-in-depth
 - Test that restricted columns are truly absent from API responses
 
+### 9. File Storage (fs-storage plugin)
+
+The filesystem storage plugin maps storage keys onto a directory tree under
+`rootDir`. Two layers keep a request from reaching a file it shouldn't:
+
+- **Key validation** — every key is checked before it touches disk: absolute
+  paths, `..`/`.`/empty segments, backslashes, control characters, and the
+  reserved upload-staging directory are all rejected. This blocks _textual_
+  path traversal.
+- **Symlink containment** (`symlinkContainment`, default **on**) — each key's
+  real path is resolved and rejected if a symlink under `rootDir` redirects it
+  outside. Key validation alone can't catch this: a symlink is a legitimate
+  path with no `..` in it. Containment costs one `realpath` syscall per file
+  operation.
+
+```typescript
+createFsStoragePlugin({
+  basePath: '/admin',
+  rootDir: './uploads',
+  // symlinkContainment defaults to true; only disable it if `rootDir` is a
+  // directory your app exclusively controls AND you intentionally use
+  // symlinks inside it.
+  symlinkContainment: false,
+});
+```
+
+**Best Practices:**
+
+- Point `rootDir` at a directory your application **exclusively controls**. The
+  symlink risk only exists if another (untrusted) process can create entries
+  under `rootDir` — e.g. a shared or multi-tenant mount.
+- Keep `symlinkContainment` on unless you have a specific reason to allow
+  symlinks inside `rootDir`. It is **not** TOCTOU-proof: a symlink swapped in
+  between the check and the file open still wins. For hard multi-tenant
+  isolation, enforce containment at the OS level (a dedicated mount, a
+  container, or `openat2(RESOLVE_BENEATH)`) rather than relying on it alone.
+- Scope the runtime's filesystem permissions to `rootDir` (e.g. Deno
+  `--allow-read`/`--allow-write` scoped to that path) as defense-in-depth —
+  though note a symlink under `rootDir` textually resolves within the granted
+  scope, so permission scoping does not by itself stop symlink escape.
+- Only set `publicBaseUrl` for buckets safe to expose: a raw static mount
+  serves bytes without the CMS row/column policy checks the `/files/` route
+  enforces.
+
 ## Environment Variables
 
 ### Required Secrets

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -294,7 +294,7 @@ createFsStoragePlugin({
   `--allow-read`/`--allow-write` scoped to that path) as defense-in-depth —
   though note a symlink under `rootDir` textually resolves within the granted
   scope, so permission scoping does not by itself stop symlink escape.
-- Only set `publicBaseUrl` for buckets safe to expose: a raw static mount
+- Only set `publicBaseUrl` for directories safe to expose: a raw static mount
   serves bytes without the CMS row/column policy checks the `/files/` route
   enforces.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -318,7 +318,8 @@ The S3 plugin serves downloads two ways, with different exposure:
   **signed cookies** scoped to the session (CloudFront/Cloudflare) or a private
   distribution. The plugin emits a **bare** URL, so a CDN that requires
   per-request **signed URLs** (rather than cookies) is not supported by this
-  option.
+  option yet — per-object signed CDN URLs are on the roadmap
+  ([#91](https://github.com/hotsauce-team/hotsauce/issues/91)).
 - A CDN gated by signed cookies enforces access at the CDN's granularity
   (typically path or session), which is **coarser** than the CMS's per-record
   row/column policy — size the cookie scope accordingly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -258,11 +258,16 @@ The filesystem storage plugin maps storage keys onto a directory tree under
   paths, `..`/`.`/empty segments, backslashes, control characters, and the
   reserved upload-staging directory are all rejected. This blocks _textual_
   path traversal.
-- **Symlink containment** (`symlinkContainment`, default **on**) — each key's
-  real path is resolved and rejected if a symlink under `rootDir` redirects it
-  outside. Key validation alone can't catch this: a symlink is a legitimate
-  path with no `..` in it. Containment costs one `realpath` syscall per file
-  operation.
+- **Symlink containment** (`symlinkContainment`, default **on**) — a key's real
+  path is resolved and an operation is refused if a symlink under `rootDir`
+  redirects it outside. Reads (`get`/`getStream`) resolve the full key and
+  reject any escape. Writes and deletes resolve the parent directory, so an
+  escape via an intermediate directory symlink is rejected while a final-segment
+  symlink is replaced (`put`) or unlinked (`delete`) in place rather than
+  followed — the link is removed, its outside target untouched. Listing skips
+  symlinked entries entirely (they are never keys the adapter created). Key
+  validation alone can't catch any of this: a symlink is a legitimate path with
+  no `..` in it. Containment costs one `realpath` syscall per file operation.
 
 ```typescript
 createFsStoragePlugin({

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -120,7 +120,13 @@
   "fmt": {
     "indentWidth": 2,
     "singleQuote": true,
-    "proseWrap": "preserve"
+    "proseWrap": "preserve",
+    "exclude": [
+      // AUTO-GENERATED bundles (written by packages/plugins/puck/build.ts) —
+      // regenerating them shouldn't require a format pass to keep CI green
+      "packages/plugins/puck/bundle-embedded.ts",
+      "packages/plugins/puck/css-embedded.ts"
+    ]
   },
 
   // Linting
@@ -138,6 +144,9 @@
     ".git/",
     "scripts/",
     // Node/tsx sub-project (sandcastle agent workflows) — not Deno code
-    ".sandcastle/"
+    ".sandcastle/",
+    // Claude Code worktrees/config — nested checkouts otherwise re-enter the
+    // graph with paths the root-relative excludes above don't match
+    ".claude/"
   ]
 }

--- a/npm-tests/fs-storage.test.js
+++ b/npm-tests/fs-storage.test.js
@@ -152,7 +152,69 @@ describe('@hotsauce/plugins-fs-storage disk adapter (Node)', () => {
     const fs = createDiskFsAdapter(dir); // containment on by default
     await assert.rejects(fs.get('escape.txt'), /outside rootDir/);
     await assert.rejects(fs.getStream('escape.txt'), /outside rootDir/);
-    await assert.rejects(fs.delete('escape.txt'), /outside rootDir/);
+  });
+
+  it('delete() removes a planted escaping symlink but leaves its target', async () => {
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await writeFile(join(outside, 'secret.txt'), 'TOP SECRET');
+    await symlink(join(outside, 'secret.txt'), join(dir, 'escape.txt'));
+
+    const fs = createDiskFsAdapter(dir);
+    // delete unlinks the link itself (safe) rather than following it — so the
+    // planted link is removable and the outside target is untouched.
+    await fs.delete('escape.txt');
+    assert.equal(
+      await lstat(join(dir, 'escape.txt')).then(() => false).catch(() => true),
+      true,
+    );
+    assert.equal(
+      await readFile(join(outside, 'secret.txt'), 'utf8'),
+      'TOP SECRET',
+    );
+  });
+
+  it('delete() still rejects a path that escapes via an intermediate directory symlink', async () => {
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await mkdir(join(outside, 'image', '1'), { recursive: true });
+    await writeFile(join(outside, 'image', '1', 'victim.bin'), 'VICTIM');
+    await symlink(outside, join(dir, 'posts')); // posts -> outside
+
+    const fs = createDiskFsAdapter(dir);
+    await assert.rejects(
+      fs.delete('posts/image/1/victim.bin'),
+      /outside rootDir/,
+    );
+    // The out-of-root victim was not deleted through the directory symlink.
+    assert.equal(
+      await readFile(join(outside, 'image', '1', 'victim.bin'), 'utf8'),
+      'VICTIM',
+    );
+  });
+
+  it('list() never enumerates a planted symlink as a key', async () => {
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await writeFile(join(outside, 'secret.txt'), 'TOP SECRET DATA');
+    const fs = createDiskFsAdapter(dir);
+    await fs.put('posts/image/1/real.bin', new Uint8Array([1, 2]));
+
+    // A file symlink and a directory symlink, both escaping rootDir.
+    await symlink(
+      join(outside, 'secret.txt'),
+      join(dir, 'posts/image/1/leak.bin'),
+    );
+    await symlink(outside, join(dir, 'posts/image/1/leakdir'));
+
+    // Only the real key is listed — no phantom keys, no foreign metadata, and
+    // walk() doesn't traverse out through the directory symlink.
+    const keys = (await fs.list('posts/image/1/')).map((e) => e.key);
+    assert.deepEqual(keys, ['posts/image/1/real.bin']);
+    assert.deepEqual(
+      (await fs.list('')).map((e) => e.key),
+      ['posts/image/1/real.bin'],
+    );
   });
 
   it('symlink containment can be turned off', async () => {

--- a/npm-tests/fs-storage.test.js
+++ b/npm-tests/fs-storage.test.js
@@ -17,6 +17,7 @@ import {
   readFile,
   rm,
   stat,
+  symlink,
   utimes,
   writeFile,
 } from 'node:fs/promises';
@@ -134,6 +135,53 @@ describe('@hotsauce/plugins-fs-storage disk adapter (Node)', () => {
     assert.deepEqual(
       (await fs.list('posts/image/1/')).map((e) => e.key),
       ['posts/image/1/real.bin'],
+    );
+  });
+
+  // Symlink containment: exercised here (not in the Deno suite) because
+  // Deno.symlink needs unscoped fs permissions the Deno test harness withholds,
+  // whereas Node creates symlinks freely — and this covers the Node realpath
+  // branch of assertContained.
+  it('symlink containment blocks a key that resolves outside rootDir', async () => {
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await writeFile(join(outside, 'secret.txt'), 'TOP SECRET');
+    // A symlink planted under rootDir pointing at a file outside it.
+    await symlink(join(outside, 'secret.txt'), join(dir, 'escape.txt'));
+
+    const fs = createDiskFsAdapter(dir); // containment on by default
+    await assert.rejects(fs.get('escape.txt'), /outside rootDir/);
+    await assert.rejects(fs.getStream('escape.txt'), /outside rootDir/);
+    await assert.rejects(fs.delete('escape.txt'), /outside rootDir/);
+  });
+
+  it('symlink containment can be turned off', async () => {
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await writeFile(join(outside, 'secret.txt'), 'TOP SECRET');
+    await symlink(join(outside, 'secret.txt'), join(dir, 'escape.txt'));
+
+    const fs = createDiskFsAdapter(dir, { symlinkContainment: false });
+    // Off: the symlink is followed and the outside file leaks through.
+    assert.equal(
+      new TextDecoder().decode(await fs.get('escape.txt')),
+      'TOP SECRET',
+    );
+  });
+
+  it('symlink containment allows links that stay inside rootDir', async () => {
+    const dir = await freshDir();
+    const fs = createDiskFsAdapter(dir);
+    await fs.put('posts/image/1/real.bin', new Uint8Array([7, 8, 9]));
+    // A symlink whose target is also under rootDir resolves cleanly.
+    await symlink(
+      join(dir, 'posts/image/1/real.bin'),
+      join(dir, 'inside-link.bin'),
+    );
+
+    assert.deepEqual(
+      await fs.get('inside-link.bin'),
+      new Uint8Array([7, 8, 9]),
     );
   });
 });

--- a/npm-tests/package.json
+++ b/npm-tests/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "node --test smoke.test.js cms.test.js fs-storage.test.js"
+    "test": "node --test smoke.test.js cms.test.js fs-storage.test.js s3-storage.test.js"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.15",

--- a/npm-tests/package.json
+++ b/npm-tests/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "node --test smoke.test.js cms.test.js fs-storage.test.js s3-storage.test.js"
+    "test": "node --test"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.15",

--- a/npm-tests/s3-storage.test.js
+++ b/npm-tests/s3-storage.test.js
@@ -1,0 +1,97 @@
+/**
+ * E2E tests for @hotsauce/plugins-s3-storage in Node.js
+ *
+ * The plugin is pure fetch + Web Crypto (no runtime forks), so this is a
+ * light smoke suite: it validates the npm build's entry points resolve, the
+ * cross-package imports survived dnt, and SigV4 signing produces identical
+ * output on Node's WebCrypto. Not meant to replace the Deno unit tests.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createS3StoragePlugin,
+  validatePresignRequest,
+} from '@hotsauce/plugins-s3-storage';
+import { presignUrl } from '@hotsauce/plugins-s3-storage/signing';
+
+function makePlugin(extra = {}) {
+  return createS3StoragePlugin({
+    endpoint: 'http://localhost:9000',
+    region: 'us-east-1',
+    bucket: 'test-bucket',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+    urlStyle: 'path',
+    basePath: '/admin',
+    ...extra,
+  });
+}
+
+describe('@hotsauce/plugins-s3-storage (Node)', () => {
+  it('factory instantiates with a storage provider and routes', () => {
+    const plugin = makePlugin();
+    assert.equal(plugin.name, 's3-storage');
+    assert.ok(plugin.storageProvider);
+    assert.ok(Array.isArray(plugin.routes) && plugin.routes.length > 0);
+  });
+
+  it('presign validation accepts */* inside an accept list', () => {
+    // Regression for the inline-matcher bug fixed in issue #89.
+    const result = validatePresignRequest(
+      { filename: 'photo.png', contentType: 'image/png', size: 1000 },
+      { file: { accept: 'application/pdf,*/*' } },
+    );
+    assert.equal(result, null);
+  });
+
+  it('presign validation rejects a non-matching content type', () => {
+    const result = validatePresignRequest(
+      { filename: 'doc.pdf', contentType: 'application/pdf', size: 1000 },
+      { file: { accept: 'image/*' } },
+    );
+    assert.ok(result);
+    assert.match(result.error, /Invalid file type/);
+  });
+
+  it('presignUrl reproduces the AWS SigV4 example vector', async () => {
+    // Same fixed-date request as the Deno sigv4 tests; the signature must be
+    // byte-identical on Node's WebCrypto.
+    const url = await presignUrl({
+      method: 'GET',
+      url: 'https://examplebucket.s3.amazonaws.com/test.txt',
+      region: 'us-east-1',
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      expirySeconds: 86400,
+      date: new Date('2013-05-24T00:00:00.000Z'),
+    });
+    assert.equal(
+      new URL(url).searchParams.get('X-Amz-Signature'),
+      'aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404',
+    );
+  });
+
+  it('signDownloadUrl builds encoded CDN URLs and rejects traversal keys', async () => {
+    const provider = makePlugin({
+      cdnBaseUrl: 'https://cdn.example.com/',
+    }).storageProvider;
+
+    assert.equal(
+      await provider.signDownloadUrl({
+        storage: 's3',
+        key: 'media/file/1/a b.png',
+      }),
+      'https://cdn.example.com/media/file/1/a%20b.png',
+    );
+
+    await assert.rejects(
+      provider.signDownloadUrl({
+        storage: 's3',
+        key: 'media/file/1/../../etc/passwd',
+      }),
+      /Invalid storage key/,
+    );
+  });
+});

--- a/npm-tests/s3-storage.test.js
+++ b/npm-tests/s3-storage.test.js
@@ -93,5 +93,15 @@ describe('@hotsauce/plugins-s3-storage (Node)', () => {
       }),
       /Invalid storage key/,
     );
+
+    // Percent-encoded traversal (a CDN might decode %2e%2e%2f -> ../) is
+    // rejected at the key validator before it reaches the URL.
+    await assert.rejects(
+      provider.signDownloadUrl({
+        storage: 's3',
+        key: 'media/file/1/%2e%2e%2f%2e%2e%2fetc/passwd',
+      }),
+      /percent-encoding/,
+    );
   });
 });

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -692,86 +692,70 @@ async function handlePluginRoute(
   try {
     if (route.handler) {
       // In-process handler
-      try {
-        const result = await route.handler(ctx);
-        if (result instanceof Response) {
-          const ct = result.headers.get('content-type') ?? '';
-          if (ct.startsWith('text/html')) {
-            // Enforce all security headers for HTML responses
-            // (plugins cannot override CSP, X-Frame-Options, etc.)
-            for (const [k, v] of Object.entries(effectiveHeaders)) {
-              result.headers.set(k, v);
-            }
-          } else {
-            // Non-HTML: enforce nosniff (prevents MIME-sniffing of CSS/JS/JSON)
-            result.headers.set('X-Content-Type-Options', 'nosniff');
+      const result = await route.handler(ctx);
+      if (result instanceof Response) {
+        const ct = result.headers.get('content-type') ?? '';
+        if (ct.startsWith('text/html')) {
+          // Enforce all security headers for HTML responses
+          // (plugins cannot override CSP, X-Frame-Options, etc.)
+          for (const [k, v] of Object.entries(effectiveHeaders)) {
+            result.headers.set(k, v);
           }
-          return result;
+        } else {
+          // Non-HTML: enforce nosniff (prevents MIME-sniffing of CSS/JS/JSON)
+          result.headers.set('X-Content-Type-Options', 'nosniff');
         }
-        // String result - wrap in HTML response with security headers
-        return new Response(result, {
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            ...effectiveHeaders,
-          },
-        });
-      } catch (error) {
-        // Generate request ID to correlate error logs with user-facing response
-        const requestId = crypto.randomUUID();
-        options.onError?.(error as Error, {
-          source: 'handler',
-          request,
-          url: new URL(request.url),
-          route: null, // Plugin routes don't use ParsedRoute
-          action: routeAction,
-          requestId,
-          plugin: plugin.name,
-        });
-        return new Response(`Plugin error (request: ${requestId})`, {
-          status: 500,
-        });
+        return result;
       }
+      // String result - wrap in HTML response with security headers
+      return new Response(result, {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          ...effectiveHeaders,
+        },
+      });
     }
 
     if (route.render && pluginService) {
       // Worker render - use executor
-      try {
-        const html = await pluginService.executeRouteRender(
-          plugin.name,
-          route.render,
-          ctx,
-        );
-        return new Response(html, {
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            ...effectiveHeaders,
-          },
-        });
-      } catch (error) {
-        // Generate request ID to correlate error logs with user-facing response
-        const requestId = crypto.randomUUID();
-        options.onError?.(error as Error, {
-          source: 'handler',
-          request,
-          url: new URL(request.url),
-          route: null, // Plugin routes don't use ParsedRoute
-          action: routeAction,
-          requestId,
-          plugin: plugin.name,
-        });
-        return new Response(`Plugin error (request: ${requestId})`, {
-          status: 500,
-        });
-      }
+      const html = await pluginService.executeRouteRender(
+        plugin.name,
+        route.render,
+        ctx,
+      );
+      return new Response(html, {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          ...effectiveHeaders,
+        },
+      });
     }
 
     // No handler or render configured (should be caught by validation)
     return new Response('Route not configured', { status: 500 });
+  } catch (error) {
+    // Generate request ID to correlate error logs with user-facing response
+    const requestId = crypto.randomUUID();
+    options.onError?.(error as Error, {
+      source: 'handler',
+      request,
+      url: new URL(request.url),
+      route: null, // Plugin routes don't use ParsedRoute
+      action: routeAction,
+      requestId,
+      plugin: plugin.name,
+    });
+    return new Response(`Plugin error (request: ${requestId})`, {
+      status: 500,
+    });
   } finally {
-    // A handler that consumed (or is still piping) the body holds the
+    // A handler that consumed the body via getReader()/pipeTo() holds the
     // stream's lock; a fully-drained, closed stream is unlocked but cancel()
-    // is then a resolved no-op. Swallow rejections — an unhandled rejection
-    // is fatal on Node.
+    // is then a resolved no-op. NOTE: new Response(bodyStream) does NOT lock
+    // the stream until serialization, so returning the raw stream as a
+    // response body is unsupported (it would be cancelled here) — see the
+    // bodyStream contract in workers/types.ts. Swallow rejections — an
+    // unhandled rejection is fatal on Node.
     if (bodyStream && !bodyStream.locked) {
       bodyStream.cancel().catch(() => {});
     }

--- a/packages/cms/mod.ts
+++ b/packages/cms/mod.ts
@@ -686,84 +686,96 @@ async function handlePluginRoute(
   const effectiveHeaders = options.routeSecurityHeaders.get(routeKey) ??
     options.securityHeaders;
 
-  // Dispatch based on route type
-  if (route.handler) {
-    // In-process handler
-    try {
-      const result = await route.handler(ctx);
-      if (result instanceof Response) {
-        const ct = result.headers.get('content-type') ?? '';
-        if (ct.startsWith('text/html')) {
-          // Enforce all security headers for HTML responses
-          // (plugins cannot override CSP, X-Frame-Options, etc.)
-          for (const [k, v] of Object.entries(effectiveHeaders)) {
-            result.headers.set(k, v);
+  // Dispatch based on route type. Dispatch owns bodyStream cleanup: once the
+  // handler settles, an unconsumed capped stream is cancelled below so the
+  // client transfer is aborted (handlers used to do this themselves).
+  try {
+    if (route.handler) {
+      // In-process handler
+      try {
+        const result = await route.handler(ctx);
+        if (result instanceof Response) {
+          const ct = result.headers.get('content-type') ?? '';
+          if (ct.startsWith('text/html')) {
+            // Enforce all security headers for HTML responses
+            // (plugins cannot override CSP, X-Frame-Options, etc.)
+            for (const [k, v] of Object.entries(effectiveHeaders)) {
+              result.headers.set(k, v);
+            }
+          } else {
+            // Non-HTML: enforce nosniff (prevents MIME-sniffing of CSS/JS/JSON)
+            result.headers.set('X-Content-Type-Options', 'nosniff');
           }
-        } else {
-          // Non-HTML: enforce nosniff (prevents MIME-sniffing of CSS/JS/JSON)
-          result.headers.set('X-Content-Type-Options', 'nosniff');
+          return result;
         }
-        return result;
+        // String result - wrap in HTML response with security headers
+        return new Response(result, {
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            ...effectiveHeaders,
+          },
+        });
+      } catch (error) {
+        // Generate request ID to correlate error logs with user-facing response
+        const requestId = crypto.randomUUID();
+        options.onError?.(error as Error, {
+          source: 'handler',
+          request,
+          url: new URL(request.url),
+          route: null, // Plugin routes don't use ParsedRoute
+          action: routeAction,
+          requestId,
+          plugin: plugin.name,
+        });
+        return new Response(`Plugin error (request: ${requestId})`, {
+          status: 500,
+        });
       }
-      // String result - wrap in HTML response with security headers
-      return new Response(result, {
-        headers: {
-          'Content-Type': 'text/html; charset=utf-8',
-          ...effectiveHeaders,
-        },
-      });
-    } catch (error) {
-      // Generate request ID to correlate error logs with user-facing response
-      const requestId = crypto.randomUUID();
-      options.onError?.(error as Error, {
-        source: 'handler',
-        request,
-        url: new URL(request.url),
-        route: null, // Plugin routes don't use ParsedRoute
-        action: routeAction,
-        requestId,
-        plugin: plugin.name,
-      });
-      return new Response(`Plugin error (request: ${requestId})`, {
-        status: 500,
-      });
+    }
+
+    if (route.render && pluginService) {
+      // Worker render - use executor
+      try {
+        const html = await pluginService.executeRouteRender(
+          plugin.name,
+          route.render,
+          ctx,
+        );
+        return new Response(html, {
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            ...effectiveHeaders,
+          },
+        });
+      } catch (error) {
+        // Generate request ID to correlate error logs with user-facing response
+        const requestId = crypto.randomUUID();
+        options.onError?.(error as Error, {
+          source: 'handler',
+          request,
+          url: new URL(request.url),
+          route: null, // Plugin routes don't use ParsedRoute
+          action: routeAction,
+          requestId,
+          plugin: plugin.name,
+        });
+        return new Response(`Plugin error (request: ${requestId})`, {
+          status: 500,
+        });
+      }
+    }
+
+    // No handler or render configured (should be caught by validation)
+    return new Response('Route not configured', { status: 500 });
+  } finally {
+    // A handler that consumed (or is still piping) the body holds the
+    // stream's lock; a fully-drained, closed stream is unlocked but cancel()
+    // is then a resolved no-op. Swallow rejections — an unhandled rejection
+    // is fatal on Node.
+    if (bodyStream && !bodyStream.locked) {
+      bodyStream.cancel().catch(() => {});
     }
   }
-
-  if (route.render && pluginService) {
-    // Worker render - use executor
-    try {
-      const html = await pluginService.executeRouteRender(
-        plugin.name,
-        route.render,
-        ctx,
-      );
-      return new Response(html, {
-        headers: {
-          'Content-Type': 'text/html; charset=utf-8',
-          ...effectiveHeaders,
-        },
-      });
-    } catch (error) {
-      // Generate request ID to correlate error logs with user-facing response
-      const requestId = crypto.randomUUID();
-      options.onError?.(error as Error, {
-        source: 'handler',
-        request,
-        url: new URL(request.url),
-        route: null, // Plugin routes don't use ParsedRoute
-        action: routeAction,
-        requestId,
-        plugin: plugin.name,
-      });
-      return new Response(`Plugin error (request: ${requestId})`, {
-        status: 500,
-      });
-    }
-  }
-
-  // No handler or render configured (should be caught by validation)
-  return new Response('Route not configured', { status: 500 });
 }
 
 /**

--- a/packages/cms/tests/plugin_route_body_size_test.ts
+++ b/packages/cms/tests/plugin_route_body_size_test.ts
@@ -263,6 +263,126 @@ Deno.test('plugin route: maxBodySize enforcement', async (t) => {
   );
 });
 
+Deno.test('plugin route: dispatch cancels an unconsumed bodyStream', async (t) => {
+  const client = new PGlite();
+  const db = drizzle(client, { schema });
+  await createBasicTables(db);
+
+  const csrfToken = await generateCsrfToken(TEST_CSRF_SECRET);
+  const csrfHeaders = { 'X-CSRF-Token': csrfToken };
+
+  const handler = createCmsHandler({
+    csrfSecret: TEST_CSRF_SECRET,
+    auth: 'dangerously-open',
+    policies: 'dangerously-open',
+    db,
+    schema,
+    basePath: '/admin',
+    plugins: [
+      {
+        name: 'cancel-test',
+        filter: 'dangerously-open' as const,
+        routes: [
+          {
+            pattern: 'consumes',
+            methods: ['POST'],
+            bodyType: 'stream',
+            handler: async (ctx) => {
+              let total = 0;
+              for await (const chunk of ctx.bodyStream!) total += chunk.length;
+              return new Response(String(total));
+            },
+          },
+          {
+            pattern: 'ignores',
+            methods: ['POST'],
+            bodyType: 'stream',
+            // Early reject without touching the stream — dispatch must cancel
+            // the unread body so the client transfer is aborted.
+            handler: () => new Response('nope', { status: 403 }),
+          },
+          {
+            pattern: 'throws',
+            methods: ['POST'],
+            bodyType: 'stream',
+            handler: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  /** Build a streaming POST whose source records upstream cancellation. */
+  const makeStreamRequest = (
+    pattern: string,
+    { close }: { close: boolean },
+  ) => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('hello'));
+        if (close) controller.close();
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const request = new Request(
+      `http://localhost/admin/cancel-test/${pattern}`,
+      {
+        method: 'POST',
+        headers: csrfHeaders,
+        body,
+        // @ts-ignore: duplex is required for streaming request bodies
+        duplex: 'half',
+      },
+    );
+    return { request, wasCancelled: () => cancelled };
+  };
+
+  // Cancellation is fire-and-forget; give the microtask a beat to land.
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  await t.step(
+    'handler consumes the stream: source is not cancelled',
+    async () => {
+      const { request, wasCancelled } = makeStreamRequest('consumes', {
+        close: true,
+      });
+      const res = await handler(request);
+      assertEquals(res.status, 200);
+      assertEquals(await res.text(), '5');
+      await tick();
+      assertEquals(wasCancelled(), false);
+    },
+  );
+
+  await t.step('handler ignores the stream: source is cancelled', async () => {
+    const { request, wasCancelled } = makeStreamRequest('ignores', {
+      close: false,
+    });
+    const res = await handler(request);
+    assertEquals(res.status, 403);
+    await tick();
+    assertEquals(wasCancelled(), true);
+  });
+
+  await t.step(
+    'handler throws before consuming: source is cancelled',
+    async () => {
+      const { request, wasCancelled } = makeStreamRequest('throws', {
+        close: false,
+      });
+      const res = await handler(request);
+      assertEquals(res.status, 500);
+      await tick();
+      assertEquals(wasCancelled(), true);
+    },
+  );
+});
+
 Deno.test('plugin route validation: maxBodySize must be a positive integer', () => {
   const registry = new PluginRegistry();
 

--- a/packages/plugins/fs-storage/README.md
+++ b/packages/plugins/fs-storage/README.md
@@ -32,6 +32,34 @@ byte path inside the CMS:
   strict `Content-Security-Policy`. The CMS `/files/` route still enforces
   row/column policies, then 302-redirects to it.
 
+## Installation
+
+**Deno / JSR** — the plugin ships as part of the `@hotsauce/plugins` package:
+
+```bash
+deno add jsr:@hotsauce/plugins
+```
+
+```ts
+import { createFsStoragePlugin } from '@hotsauce/plugins/fs-storage';
+```
+
+**Node / npm** — published standalone as
+[`@hotsauce/plugins-fs-storage`](https://www.npmjs.com/package/@hotsauce/plugins-fs-storage)
+(note the different import specifier):
+
+```bash
+npm install @hotsauce/plugins-fs-storage
+```
+
+```ts
+import { createFsStoragePlugin } from '@hotsauce/plugins-fs-storage';
+```
+
+Sub-exports follow the same shape on both registries: types at
+`@hotsauce/plugins/fs-storage/types` (JSR) /
+`@hotsauce/plugins-fs-storage/types` (npm).
+
 ## Usage
 
 ```typescript

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -324,6 +324,19 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     }
   }
 
+  // `tempDir` is fixed for the adapter's lifetime, so create it once and
+  // memoize (like `nodeFsPromise` above) instead of paying a recursive mkdir
+  // on every upload. A failure is not memoized: the first upload before
+  // `rootDir` exists must not poison every later one.
+  let tempDirReady: Promise<void> | null = null;
+  function ensureTempDir(): Promise<void> {
+    tempDirReady ??= ensureDir(tempDir).catch((err) => {
+      tempDirReady = null;
+      throw err;
+    });
+    return tempDirReady;
+  }
+
   /** Best-effort removal of a temp file (ignores "not found"). */
   async function removeQuietly(path: string): Promise<void> {
     try {
@@ -370,8 +383,9 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
   return {
     async put(key, data, opts) {
       const path = keyToPath(rootDir, key);
-      await ensureDir(parentDir(path));
-      await ensureDir(tempDir);
+      // The parent dir varies per key; the memoized temp-dir creation runs
+      // concurrently instead of serializing a second awaited mkdir on it.
+      await Promise.all([ensureDir(parentDir(path)), ensureTempDir()]);
 
       // Opportunistically reclaim temps orphaned by an earlier crashed upload
       // (throttled). Runs before the new temp is created, so it never targets

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -355,14 +355,18 @@ export function createDiskFsAdapter(
   const Deno = denoNs();
   const symlinkContainment = opts.symlinkContainment ?? true;
 
-  const base = rootDir.replace(/\/+$/, '');
-  // A root-only rootDir ('/', '//', …) collapses to '' and would map keys onto
-  // the filesystem root (`/${key}`). Reject it up front: otherwise operations
-  // fail later with a confusing realPath('') NotFound, and without containment
-  // it would silently write at `/`.
-  if (base === '') {
+  // Trim trailing separators, forward and back (Windows accepts both).
+  const base = rootDir.replace(/[/\\]+$/, '');
+  // Reject a root that maps keys onto a filesystem/drive root rather than a
+  // dedicated subdirectory — POSIX '/'/'//' (→ ''), or a Windows drive/UNC
+  // root like 'C:\', 'C:', 'C:/', or '\\'. Otherwise a key would resolve to
+  // `${root}/${key}` at the very top of a volume: without containment it writes
+  // there silently, and with it operations fail later with a confusing
+  // realPath NotFound. `base` is what remains after trailing separators are
+  // stripped, so a root-only value is an optional drive letter plus separators.
+  if (/^([a-zA-Z]:)?[/\\]*$/.test(base)) {
     throw new Error(
-      'fs-storage: rootDir must not be the filesystem root; use a dedicated subdirectory.',
+      'fs-storage: rootDir must not be a filesystem or drive root; use a dedicated subdirectory.',
     );
   }
   // In-flight uploads are written here, not beside their final path, so a temp

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -337,6 +337,21 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     return tempDirReady;
   }
 
+  /**
+   * The memo above never re-checks the staging dir, so an out-of-band
+   * deletion (tmp reaper, operator cleanup) would otherwise fail every later
+   * upload with ENOENT. On a not-found failure, drop the memo so the next
+   * `put` recreates the dir. (The failing upload itself can't be retried —
+   * a streamed body is already consumed by then.)
+   */
+  function resetTempDirIfLost(err: unknown): void {
+    const name = (err as { name?: string })?.name;
+    const code = (err as { code?: string })?.code;
+    if (name === 'NotFound' || code === 'ENOENT') {
+      tempDirReady = null;
+    }
+  }
+
   /** Best-effort removal of a temp file (ignores "not found"). */
   async function removeQuietly(path: string): Promise<void> {
     try {
@@ -408,6 +423,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
             await fs.writeFile(tmp, data);
           }
         } catch (err) {
+          resetTempDirIfLost(err);
           await removeQuietly(tmp);
           throw err;
         }
@@ -429,6 +445,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
           }
           assertExpectedSize(getCount(), opts?.expectedSize);
         } catch (err) {
+          resetTempDirIfLost(err);
           await removeQuietly(tmp);
           throw err;
         }
@@ -445,6 +462,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
           await fs.rename(tmp, path);
         }
       } catch (err) {
+        resetTempDirIfLost(err);
         await removeQuietly(tmp);
         throw err;
       }

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -292,8 +292,32 @@ function parentDir(path: string): string {
  * The caller (the user's server) is responsible for granting the runtime
  * read/write permission to `rootDir`.
  */
-export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
+/** Options for {@link createDiskFsAdapter}. */
+export interface DiskFsAdapterOptions {
+  /**
+   * Resolve each key's real filesystem path (following symlinks) and reject it
+   * if it escapes `rootDir`. `assertSafeKey` blocks textual traversal (`..`,
+   * absolute paths), but a symlink planted under `rootDir` by another process
+   * would otherwise let a key read or write outside it. Costs one extra
+   * `realpath` syscall per `get`/`getStream`/`delete`/`put`.
+   *
+   * Leave this on unless `rootDir` is a directory your application exclusively
+   * controls AND you legitimately place symlinks inside it. Not TOCTOU-proof
+   * (a symlink swapped in after the check still wins); for hard multi-tenant
+   * isolation prefer an OS sandbox (a dedicated mount, container, or
+   * `RESOLVE_BENEATH`). See SECURITY.md.
+   *
+   * @default true
+   */
+  symlinkContainment?: boolean;
+}
+
+export function createDiskFsAdapter(
+  rootDir: string,
+  opts: DiskFsAdapterOptions = {},
+): FileSystemAdapter {
   const Deno = denoNs();
+  const symlinkContainment = opts.symlinkContainment ?? true;
 
   const base = rootDir.replace(/\/+$/, '');
   // In-flight uploads are written here, not beside their final path, so a temp
@@ -333,6 +357,52 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     return path;
   }
 
+  function isMissing(err: unknown): boolean {
+    const name = (err as { name?: string })?.name;
+    const code = (err as { code?: string })?.code;
+    return name === 'NotFound' || code === 'ENOENT';
+  }
+
+  async function realPath(p: string): Promise<string> {
+    if (Deno) return await Deno.realPath(p);
+    return await (await nodeFs()).realpath(p);
+  }
+
+  // `rootDir` may itself be a symlink (e.g. /var/data -> /mnt/vol); resolve it
+  // once so containment compares real paths to real paths. Memoized like the
+  // temp dir; a failure (base not created yet) is not cached.
+  let realBaseReady: Promise<string> | null = null;
+  function ensureRealBase(): Promise<string> {
+    realBaseReady ??= realPath(base).catch((err) => {
+      realBaseReady = null;
+      throw err;
+    });
+    return realBaseReady;
+  }
+
+  /**
+   * Resolve `path` and assert its real location stays within `rootDir`, so a
+   * symlink under `rootDir` can't redirect a key outside it. A missing path is
+   * left for the caller's own operation to report (preserving NotFound /
+   * idempotent-delete semantics). No-op when `symlinkContainment` is off.
+   */
+  async function assertContained(path: string): Promise<void> {
+    if (!symlinkContainment) return;
+    let real: string;
+    try {
+      real = await realPath(path);
+    } catch (err) {
+      if (isMissing(err)) return; // the real op will surface the missing path
+      throw err;
+    }
+    const realBase = await ensureRealBase();
+    if (real !== realBase && !real.startsWith(`${realBase}/`)) {
+      throw new Error(
+        `Invalid storage key: resolves outside rootDir (symlink escape)`,
+      );
+    }
+  }
+
   async function ensureDir(dir: string): Promise<void> {
     if (Deno) {
       await Deno.mkdir(dir, { recursive: true });
@@ -348,10 +418,14 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
   // `rootDir` exists must not poison every later one.
   let tempDirReady: Promise<void> | null = null;
   function ensureTempDir(): Promise<void> {
-    tempDirReady ??= ensureDir(tempDir).catch((err) => {
-      tempDirReady = null;
-      throw err;
-    });
+    tempDirReady ??= ensureDir(tempDir)
+      // Staged bytes are written here before the rename, so verify the staging
+      // dir itself isn't a symlink escaping rootDir (checked once per memo).
+      .then(() => assertContained(tempDir))
+      .catch((err) => {
+        tempDirReady = null;
+        throw err;
+      });
     return tempDirReady;
   }
 
@@ -419,6 +493,12 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
       // The parent dir varies per key; the memoized temp-dir creation runs
       // concurrently instead of serializing a second awaited mkdir on it.
       await Promise.all([ensureDir(parentDir(path)), ensureTempDir()]);
+
+      // The final path doesn't exist yet, so check its (now-created) parent:
+      // if a symlink under rootDir redirected it outside, reject before writing
+      // any bytes. mkdir may have created stray empty dirs outside root, but no
+      // file content is committed.
+      await assertContained(parentDir(path));
 
       // Opportunistically reclaim temps orphaned by an earlier crashed upload
       // (throttled). Runs before the new temp is created, so it never targets
@@ -488,6 +568,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
 
     async get(key) {
       const path = resolveKeyPath(key);
+      await assertContained(path);
       if (Deno) {
         return await Deno.readFile(path);
       }
@@ -498,6 +579,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
 
     async getStream(key) {
       const path = resolveKeyPath(key);
+      await assertContained(path);
       if (Deno) {
         // `Deno.open` rejects if the file is missing; the returned `readable`
         // closes the fd when the body is fully read or cancelled.
@@ -521,6 +603,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
 
     async delete(key) {
       const path = resolveKeyPath(key);
+      await assertContained(path);
       try {
         if (Deno) {
           await Deno.remove(path);

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -19,6 +19,33 @@
  * runtime-agnostic, but the suite also includes scoped disk-adapter tests under
  * `packages/plugins/fs-storage/tests/.tmp` (see `deno.jsonc` test permissions).
  *
+ * ## Key safety and symlink containment
+ *
+ * Two layers keep an operation from touching a file outside `rootDir`:
+ *
+ * 1. **Textual key validation** (`assertSafeKey`, always on): rejects absolute
+ *    paths, backslashes, control chars, and `.`/`..`/empty segments before a
+ *    key becomes a path. This alone can't stop a *symlink* planted under
+ *    `rootDir` — a symlink is a legitimate path with no `..` in it.
+ * 2. **Symlink containment** (`symlinkContainment`, default on): resolves real
+ *    paths (`realpath`) and refuses operations that escape `rootDir`. The check
+ *    is asymmetric by necessity, because the two kinds of operation follow
+ *    symlinks differently:
+ *    - **Reads** (`get`/`getStream`) *follow* the final component to read it, so
+ *      they resolve the **full key path** and reject any escape.
+ *    - **Writes/removes** (`put`/`delete`) do **not** follow the final
+ *      component — `rename` replaces it and `remove` unlinks it — so they
+ *      resolve only the **parent** container. An escape via an intermediate
+ *      directory symlink is still rejected; a final-segment symlink is replaced
+ *      (`put`) or unlinked (`delete`) in place, so a planted link is removable
+ *      without its outside target ever being written or read.
+ *    - **`list`** skips symlinked entries entirely — the adapter only ever
+ *      creates regular files and real directories, so a symlink is never a key
+ *      it produced.
+ *
+ * Containment is not TOCTOU-proof and is opt-out; see SECURITY.md for the
+ * deployment guidance (dedicated `rootDir`, OS-level isolation for multi-tenant).
+ *
  * @module
  */
 

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -315,6 +315,24 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
   // instance (the adapter is normally long-lived, built once at startup).
   let lastSweepAt = 0;
 
+  /**
+   * `keyToPath` plus this adapter's reserved-name rule: a key must not point
+   * into the staging dir. `assertSafeKey` allows a leading-dot segment, but a
+   * key under {@link TEMP_DIRNAME} would be hidden from `list()` and — worse —
+   * deleted by {@link sweepStaleTemps}, which assumes everything there is an
+   * orphaned temp. (CMS-minted keys always start with a table name, so this
+   * only guards direct adapter API use.)
+   */
+  function resolveKeyPath(key: string): string {
+    const path = keyToPath(rootDir, key);
+    if (key === TEMP_DIRNAME || key.startsWith(`${TEMP_DIRNAME}/`)) {
+      throw new Error(
+        `Invalid storage key: "${TEMP_DIRNAME}" is reserved for upload staging`,
+      );
+    }
+    return path;
+  }
+
   async function ensureDir(dir: string): Promise<void> {
     if (Deno) {
       await Deno.mkdir(dir, { recursive: true });
@@ -397,7 +415,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
 
   return {
     async put(key, data, opts) {
-      const path = keyToPath(rootDir, key);
+      const path = resolveKeyPath(key);
       // The parent dir varies per key; the memoized temp-dir creation runs
       // concurrently instead of serializing a second awaited mkdir on it.
       await Promise.all([ensureDir(parentDir(path)), ensureTempDir()]);
@@ -469,7 +487,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     },
 
     async get(key) {
-      const path = keyToPath(rootDir, key);
+      const path = resolveKeyPath(key);
       if (Deno) {
         return await Deno.readFile(path);
       }
@@ -479,7 +497,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     },
 
     async getStream(key) {
-      const path = keyToPath(rootDir, key);
+      const path = resolveKeyPath(key);
       if (Deno) {
         // `Deno.open` rejects if the file is missing; the returned `readable`
         // closes the fd when the body is fully read or cancelled.
@@ -502,7 +520,7 @@ export function createDiskFsAdapter(rootDir: string): FileSystemAdapter {
     },
 
     async delete(key) {
-      const path = keyToPath(rootDir, key);
+      const path = resolveKeyPath(key);
       try {
         if (Deno) {
           await Deno.remove(path);

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -444,11 +444,22 @@ export function createDiskFsAdapter(
     return realBaseReady;
   }
 
+  // Two containment checks, one per operation kind — the asymmetry is the point
+  // (see the module header's "Key safety and symlink containment"):
+  //   • assertContained(path)       — reads: the op *follows* the final
+  //     component, so the fully-resolved path must be inside rootDir.
+  //   • assertParentContained(path) — writes/deletes: rename/remove act on the
+  //     final node itself (replace/unlink, no follow), so only its parent must
+  //     be inside rootDir.
+  // Both no-op when `symlinkContainment` is off.
+
   /**
-   * Resolve `path` and assert its real location stays within `rootDir`, so a
-   * symlink under `rootDir` can't redirect a key outside it. A missing path is
-   * left for the caller's own operation to report (preserving NotFound /
-   * idempotent-delete semantics). No-op when `symlinkContainment` is off.
+   * Resolve `path` in full (following a final-segment symlink) and assert its
+   * real location stays within `rootDir`. Use for **reads** (`get`/`getStream`)
+   * and for a location that must itself be inside root (the staging dir): the
+   * caller dereferences `path`, so an escaping final symlink must be rejected
+   * up front. A missing path is left for the caller's own operation to report
+   * (preserving NotFound semantics).
    */
   async function assertContained(path: string): Promise<void> {
     if (!symlinkContainment) return;
@@ -465,6 +476,19 @@ export function createDiskFsAdapter(
         `Invalid storage key: resolves outside rootDir (symlink escape)`,
       );
     }
+  }
+
+  /**
+   * Assert the **parent** of `path` stays within `rootDir`. Use for **writes
+   * and deletes**: `rename`/`remove` operate on the final node itself
+   * (replacing or unlinking a symlink rather than following it), so only its
+   * container must be contained. Checking the full path instead would reject
+   * replacing or removing a key that happens to be a symlink — and leave a
+   * planted escaping link un-removable. An intermediate directory symlink still
+   * escapes the parent and is rejected.
+   */
+  function assertParentContained(path: string): Promise<void> {
+    return assertContained(parentDir(path));
   }
 
   async function ensureDir(dir: string): Promise<void> {
@@ -568,7 +592,7 @@ export function createDiskFsAdapter(
       // permission at the target. Checking before mkdir would need a walk up to
       // the deepest existing ancestor (extra syscalls per upload) to avoid only
       // that empty-dir side effect, which isn't worth it.
-      await assertContained(parentDir(path));
+      await assertParentContained(path);
 
       // Opportunistically reclaim temps orphaned by an earlier crashed upload
       // (throttled). Runs before the new temp is created, so it never targets
@@ -673,14 +697,10 @@ export function createDiskFsAdapter(
 
     async delete(key) {
       const path = resolveKeyPath(key);
-      // Removing an entry (like renaming onto it in `put`) doesn't follow a
-      // final-segment symlink — remove/rm unlink the link itself, leaving its
-      // target untouched — so only the parent container must stay within
-      // rootDir. Checking the fully-resolved path (as get/getStream do, since
-      // they *read through* the link) would instead reject a planted escaping
-      // symlink and leave it un-removable. An intermediate directory symlink
-      // still escapes the parent check and is rejected.
-      await assertContained(parentDir(path));
+      // remove() unlinks the final node itself (a symlink here is removed, not
+      // followed), so containment is checked on the parent. See
+      // assertParentContained.
+      await assertParentContained(path);
       try {
         if (Deno) {
           await Deno.remove(path);

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -194,6 +194,15 @@ export function assertSafeKey(key: string): void {
   if (/[\x00-\x1f\x7f]/.test(key)) {
     throw new Error('Invalid storage key: control character');
   }
+  // Reject percent-encoding. Keys are minted from a restricted charset and
+  // never contain '%'. On disk `%2f`/`%2e` are literal characters (the path is
+  // not URL-decoded), but the `publicBaseUrl` static-serve branch embeds the
+  // key in a URL a proxy/CDN may decode into a separator or dot-segment
+  // (%2f -> '/', %2e -> '.') — smuggling traversal past the literal checks
+  // below. Reject the encoded form at the source, matching s3-storage.
+  if (key.includes('%')) {
+    throw new Error(`Invalid storage key: percent-encoding in "${key}"`);
+  }
   const segments = key.split('/');
   for (const segment of segments) {
     if (segment === '' || segment === '.' || segment === '..') {

--- a/packages/plugins/fs-storage/adapter.ts
+++ b/packages/plugins/fs-storage/adapter.ts
@@ -320,6 +320,15 @@ export function createDiskFsAdapter(
   const symlinkContainment = opts.symlinkContainment ?? true;
 
   const base = rootDir.replace(/\/+$/, '');
+  // A root-only rootDir ('/', '//', …) collapses to '' and would map keys onto
+  // the filesystem root (`/${key}`). Reject it up front: otherwise operations
+  // fail later with a confusing realPath('') NotFound, and without containment
+  // it would silently write at `/`.
+  if (base === '') {
+    throw new Error(
+      'fs-storage: rootDir must not be the filesystem root; use a dedicated subdirectory.',
+    );
+  }
   // In-flight uploads are written here, not beside their final path, so a temp
   // file can never collide with (or be mistaken for) a real key. The leading
   // dot is a segment the key sanitizer never produces, so `list()` can skip it
@@ -368,9 +377,24 @@ export function createDiskFsAdapter(
     return await (await nodeFs()).realpath(p);
   }
 
+  // `realPath` normalizes its output to the OS path separator, so the
+  // containment prefix check below must use that separator — on Windows a
+  // contained path (`C:\root\x`) would otherwise fail `startsWith('C:\root/')`
+  // and every operation would be rejected. Detected via the feature-detected
+  // runtime, like the I/O calls above.
+  const nodeProcess =
+    (globalThis as unknown as { process?: { platform?: string } }).process;
+  const isWindows = Deno
+    ? Deno.build?.os === 'windows'
+    : nodeProcess?.platform === 'win32';
+  const pathSep = isWindows ? '\\' : '/';
+
   // `rootDir` may itself be a symlink (e.g. /var/data -> /mnt/vol); resolve it
   // once so containment compares real paths to real paths. Memoized like the
-  // temp dir; a failure (base not created yet) is not cached.
+  // temp dir; a failure (base not created yet) is not cached. The resolved
+  // base is held for the adapter's lifetime, so if `rootDir` is repointed to a
+  // new target while the process runs, restart to pick it up — otherwise
+  // containment compares against the stale target and rejects valid keys.
   let realBaseReady: Promise<string> | null = null;
   function ensureRealBase(): Promise<string> {
     realBaseReady ??= realPath(base).catch((err) => {
@@ -396,7 +420,7 @@ export function createDiskFsAdapter(
       throw err;
     }
     const realBase = await ensureRealBase();
-    if (real !== realBase && !real.startsWith(`${realBase}/`)) {
+    if (real !== realBase && !real.startsWith(`${realBase}${pathSep}`)) {
       throw new Error(
         `Invalid storage key: resolves outside rootDir (symlink escape)`,
       );
@@ -494,10 +518,16 @@ export function createDiskFsAdapter(
       // concurrently instead of serializing a second awaited mkdir on it.
       await Promise.all([ensureDir(parentDir(path)), ensureTempDir()]);
 
-      // The final path doesn't exist yet, so check its (now-created) parent:
-      // if a symlink under rootDir redirected it outside, reject before writing
-      // any bytes. mkdir may have created stray empty dirs outside root, but no
-      // file content is committed.
+      // The final path doesn't exist yet, so check its (now-created) parent: if
+      // a symlink under rootDir redirected it outside, reject before writing any
+      // bytes. This runs after ensureDir, so a pre-planted intermediate
+      // directory symlink means the recursive mkdir will already have created
+      // empty dirs at the symlink's target — but no file content is ever
+      // committed there, no data is read, and triggering it requires write
+      // access under rootDir (to plant the symlink) plus process write
+      // permission at the target. Checking before mkdir would need a walk up to
+      // the deepest existing ancestor (extra syscalls per upload) to avoid only
+      // that empty-dir side effect, which isn't worth it.
       await assertContained(parentDir(path));
 
       // Opportunistically reclaim temps orphaned by an earlier crashed upload
@@ -603,7 +633,14 @@ export function createDiskFsAdapter(
 
     async delete(key) {
       const path = resolveKeyPath(key);
-      await assertContained(path);
+      // Removing an entry (like renaming onto it in `put`) doesn't follow a
+      // final-segment symlink — remove/rm unlink the link itself, leaving its
+      // target untouched — so only the parent container must stay within
+      // rootDir. Checking the fully-resolved path (as get/getStream do, since
+      // they *read through* the link) would instead reject a planted escaping
+      // symlink and leave it un-removable. An intermediate directory symlink
+      // still escapes the parent check and is rejected.
+      await assertContained(parentDir(path));
       try {
         if (Deno) {
           await Deno.remove(path);
@@ -636,12 +673,18 @@ export function createDiskFsAdapter(
 
       async function walk(relDir: string): Promise<void> {
         const absDir = relDir ? `${base}/${relDir}` : base;
-        let entries: Array<{ name: string; isDir: boolean }>;
+        let entries: Array<
+          { name: string; isDir: boolean; isSymlink: boolean }
+        >;
         try {
           if (Deno) {
             entries = [];
             for await (const e of Deno.readDir(absDir)) {
-              entries.push({ name: e.name, isDir: e.isDirectory });
+              entries.push({
+                name: e.name,
+                isDir: e.isDirectory,
+                isSymlink: e.isSymlink,
+              });
             }
           } else {
             const fs = await nodeFs();
@@ -652,6 +695,7 @@ export function createDiskFsAdapter(
             entries = dirents.map((d) => ({
               name: d.name,
               isDir: d.isDirectory(),
+              isSymlink: d.isSymbolicLink(),
             }));
           }
         } catch (err) {
@@ -665,6 +709,13 @@ export function createDiskFsAdapter(
           // Never descend into the in-flight upload staging dir — temp files
           // there are not real keys.
           if (!relDir && entry.name === TEMP_DIRNAME) continue;
+          // The adapter only ever creates regular files (write+rename) and real
+          // directories (mkdir), so a symlink is never a key it produced. Skip
+          // it unconditionally: enumerating one would `stat`-follow it and
+          // report a foreign target's size/mtime as a key, and feed orphan-GC a
+          // phantom it can't reclaim. (Independent of `symlinkContainment`,
+          // which governs whether get/delete *follow* a caller-named key.)
+          if (entry.isSymlink) continue;
           const childRel = relDir ? `${relDir}/${entry.name}` : entry.name;
           if (entry.isDir) {
             await walk(childRel);

--- a/packages/plugins/fs-storage/mod.ts
+++ b/packages/plugins/fs-storage/mod.ts
@@ -656,20 +656,15 @@ export function createFsStoragePlugin(
         maxBodySize: options.maxUploadBytes,
         bodyType: 'stream',
         handler: async (ctx) => {
-          // Rejections before `fs.put` leave the request body unread; cancel
-          // it so runtimes that don't auto-discard an unread body aren't left
-          // holding the connection open until the client finishes uploading.
-          const reject = (res: Response): Response => {
-            ctx.bodyStream?.cancel().catch(() => {});
-            return res;
-          };
-
+          // Rejections before `fs.put` leave the request body unread; dispatch
+          // cancels the unconsumed stream after the handler settles, so early
+          // returns can hand back the error Response directly.
           let token: string | null = null;
           try {
             token = new URL(ctx.requestUrl).searchParams.get('token');
           } catch { /* malformed URL */ }
           if (!token) {
-            return reject(jsonResponse({ error: 'Missing token' }, 400));
+            return jsonResponse({ error: 'Missing token' }, 400);
           }
 
           const payload = await verifyToken(
@@ -678,9 +673,7 @@ export function createFsStoragePlugin(
             'upload',
           );
           if (!payload) {
-            return reject(
-              jsonResponse({ error: 'Invalid or expired token' }, 403),
-            );
+            return jsonResponse({ error: 'Invalid or expired token' }, 403);
           }
 
           // Defense-in-depth: the key must match the bound record.
@@ -692,7 +685,7 @@ export function createFsStoragePlugin(
               payload.recordId,
             )
           ) {
-            return reject(jsonResponse({ error: 'Invalid key' }, 403));
+            return jsonResponse({ error: 'Invalid key' }, 403);
           }
 
           // Enforce the token-bound content type: the request must declare the
@@ -702,9 +695,9 @@ export function createFsStoragePlugin(
           const essence = (v: string | undefined) =>
             (v ?? '').split(';')[0]!.trim().toLowerCase();
           if (essence(ctx.contentType) !== essence(payload.contentType)) {
-            return reject(jsonResponse({
+            return jsonResponse({
               error: 'Content-Type does not match the upload token',
-            }, 415));
+            }, 415);
           }
 
           if (!ctx.bodyStream) {
@@ -720,17 +713,14 @@ export function createFsStoragePlugin(
               expectedSize: payload.size,
             });
           } catch (err) {
-            // `reject` is safe here even when `put` already consumed the
-            // stream: cancelling a locked/finished stream just rejects, and
-            // that rejection is swallowed.
             const name = (err as { name?: string })?.name;
             if (name === 'BodyTooLargeError') {
-              return reject(jsonResponse({ error: 'File too large' }, 413));
+              return jsonResponse({ error: 'File too large' }, 413);
             }
             if (name === 'SizeMismatchError') {
-              return reject(jsonResponse({ error: 'Size mismatch' }, 400));
+              return jsonResponse({ error: 'Size mismatch' }, 400);
             }
-            return reject(jsonResponse({ error: 'Failed to write file' }, 500));
+            return jsonResponse({ error: 'Failed to write file' }, 500);
           }
 
           return jsonResponse({ ok: true, key: payload.key });

--- a/packages/plugins/fs-storage/mod.ts
+++ b/packages/plugins/fs-storage/mod.ts
@@ -66,6 +66,7 @@ import { UPLOAD_JS } from './upload-script.ts';
 
 // Re-export types for convenience
 export type { FileSystemAdapter, FsStoragePluginOptions } from './types.ts';
+export type { DiskFsAdapterOptions } from './adapter.ts';
 export {
   assertSafeKey,
   createDiskFsAdapter,
@@ -341,7 +342,9 @@ export function createFsStoragePlugin(
         'fs-storage: rootDir is required (a non-empty directory path) when no custom fs adapter is provided.',
       );
     }
-    fs = createDiskFsAdapter(rootDir);
+    fs = createDiskFsAdapter(rootDir, {
+      symlinkContainment: pluginOptions.symlinkContainment,
+    });
   }
 
   const options: ResolvedFsOptions = {

--- a/packages/plugins/fs-storage/signing.ts
+++ b/packages/plugins/fs-storage/signing.ts
@@ -14,6 +14,11 @@
  * @module
  */
 
+// Sign/verify run on every presign, upload, and serve; reuse one encoder and
+// decoder instead of constructing fresh ones on that hot path.
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 function bytesToBase64Url(bytes: Uint8Array): string {
   let bin = '';
   for (let i = 0; i < bytes.length; i++) {
@@ -32,7 +37,7 @@ function base64UrlToBytes(s: string): Uint8Array<ArrayBuffer> {
 }
 
 function encodeJson(value: unknown): string {
-  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+  return bytesToBase64Url(textEncoder.encode(JSON.stringify(value)));
 }
 
 // The signing secret is fixed for the plugin's lifetime, but tokens are
@@ -46,7 +51,7 @@ function importKey(secret: string): Promise<CryptoKey> {
   if (!key) {
     key = crypto.subtle.importKey(
       'raw',
-      new TextEncoder().encode(secret),
+      textEncoder.encode(secret),
       { name: 'HMAC', hash: 'SHA-256' },
       false,
       ['sign', 'verify'],
@@ -105,7 +110,7 @@ export async function signToken(
   const sig = await crypto.subtle.sign(
     'HMAC',
     key,
-    new TextEncoder().encode(encoded),
+    textEncoder.encode(encoded),
   );
   return `${encoded}.${bytesToBase64Url(new Uint8Array(sig))}`;
 }
@@ -137,7 +142,7 @@ export async function verifyToken<K extends TokenPayload['kind']>(
       'HMAC',
       key,
       base64UrlToBytes(sigPart),
-      new TextEncoder().encode(encoded),
+      textEncoder.encode(encoded),
     );
   } catch {
     return null;
@@ -146,7 +151,7 @@ export async function verifyToken<K extends TokenPayload['kind']>(
 
   let payload: TokenPayload;
   try {
-    payload = JSON.parse(new TextDecoder().decode(base64UrlToBytes(encoded)));
+    payload = JSON.parse(textDecoder.decode(base64UrlToBytes(encoded)));
   } catch {
     return null;
   }

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -320,6 +320,12 @@ Deno.test('disk adapter: put streams to disk and enforces expectedSize', async (
   });
 });
 
+// NOTE: symlink-containment escape/toggle cases live in
+// npm-tests/fs-storage.test.js — Deno.symlink requires unscoped fs
+// permissions the test harness withholds, while Node creates symlinks freely
+// (and that also covers the Node realpath branch). The disk tests here all run
+// with containment ON by default, so they cover the non-escape realpath path.
+
 Deno.test('disk adapter: rejects keys under the reserved staging dir', async () => {
   await withDiskDir(async (dir) => {
     const fs = createDiskFsAdapter(dir);

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -339,6 +339,19 @@ Deno.test('disk adapter: sequential puts both commit (memoized temp dir)', async
       await Deno.readFile(keyToPath(dir, 'posts/image/1/b.bin')),
       new Uint8Array([3, 4, 5]),
     );
+
+    // Out-of-band deletion of the staging dir (tmp reaper, operator cleanup)
+    // must not wedge the adapter: the interrupted put fails, but the memo is
+    // dropped so the next put recreates the dir and succeeds.
+    await Deno.remove(`${dir}/.uploads-tmp`, { recursive: true });
+    await assertRejects(() =>
+      fs.put('posts/image/1/c.bin', new Uint8Array([6]))
+    );
+    await fs.put('posts/image/1/c.bin', new Uint8Array([6]));
+    assertEquals(
+      await Deno.readFile(keyToPath(dir, 'posts/image/1/c.bin')),
+      new Uint8Array([6]),
+    );
   });
 });
 

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -227,6 +227,12 @@ Deno.test('keyToPath: throws on traversal before producing a path', () => {
   assertThrows(() => keyToPath('/var/data', 'posts/../../etc/passwd'));
 });
 
+Deno.test('createDiskFsAdapter: rejects a filesystem-root rootDir', () => {
+  // '/', '//', … collapse to an empty base and would map keys onto '/'.
+  assertThrows(() => createDiskFsAdapter('/'), Error, 'filesystem root');
+  assertThrows(() => createDiskFsAdapter('///'), Error, 'filesystem root');
+});
+
 // ─────────────────────────────────────────────────────────────
 // In-memory adapter
 // ─────────────────────────────────────────────────────────────

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -237,10 +237,15 @@ Deno.test('keyToPath: throws on traversal before producing a path', () => {
   assertThrows(() => keyToPath('/var/data', 'posts/../../etc/passwd'));
 });
 
-Deno.test('createDiskFsAdapter: rejects a filesystem-root rootDir', () => {
-  // '/', '//', … collapse to an empty base and would map keys onto '/'.
-  assertThrows(() => createDiskFsAdapter('/'), Error, 'filesystem root');
-  assertThrows(() => createDiskFsAdapter('///'), Error, 'filesystem root');
+Deno.test('createDiskFsAdapter: rejects a filesystem- or drive-root rootDir', () => {
+  // POSIX roots collapse to an empty base; Windows drive/UNC roots would map
+  // keys onto the drive root. All are rejected.
+  for (const root of ['/', '///', 'C:\\', 'C:', 'C:/', '\\\\']) {
+    assertThrows(() => createDiskFsAdapter(root), Error, 'root');
+  }
+  // A real subdirectory (POSIX or Windows) is accepted.
+  createDiskFsAdapter('/var/data');
+  createDiskFsAdapter('C:\\uploads');
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -320,6 +320,28 @@ Deno.test('disk adapter: put streams to disk and enforces expectedSize', async (
   });
 });
 
+Deno.test('disk adapter: rejects keys under the reserved staging dir', async () => {
+  await withDiskDir(async (dir) => {
+    const fs = createDiskFsAdapter(dir);
+
+    // A key inside .uploads-tmp would be hidden from list() and reaped by the
+    // stale-temp sweeper — reserved for staging, so every method rejects it.
+    for (const key of ['.uploads-tmp', '.uploads-tmp/evil.bin']) {
+      await assertRejects(
+        () => fs.put(key, new Uint8Array([1])),
+        Error,
+        'reserved',
+      );
+      await assertRejects(() => fs.get(key), Error, 'reserved');
+      await assertRejects(() => fs.delete(key), Error, 'reserved');
+    }
+
+    // A merely dot-prefixed sibling is still a legal key.
+    await fs.put('.uploads/ok.bin', new Uint8Array([1]));
+    assertEquals((await fs.list('.uploads/')).length, 1);
+  });
+});
+
 Deno.test('disk adapter: sequential puts both commit (memoized temp dir)', async () => {
   await withDiskDir(async (dir) => {
     const fs = createDiskFsAdapter(dir);

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -216,6 +216,16 @@ Deno.test('assertSafeKey: rejects absolute paths and backslashes', () => {
   assertThrows(() => assertSafeKey(''));
 });
 
+Deno.test('assertSafeKey: rejects percent-encoding', () => {
+  // Encoded separators/dot-segments a URL consumer might decode into traversal.
+  assertThrows(
+    () => assertSafeKey('posts/%2e%2e%2fetc/passwd'),
+    Error,
+    'percent',
+  );
+  assertThrows(() => assertSafeKey('posts/a%2fb'), Error, 'percent');
+});
+
 Deno.test('keyToPath: maps a safe key under rootDir', () => {
   assertEquals(
     keyToPath('/var/data/', 'posts/image/42/x.png'),

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -814,28 +814,8 @@ Deno.test('routes: _upload rejects an invalid token', async () => {
   assertEquals(res.status, 403);
 });
 
-Deno.test('routes: _upload cancels the unread body stream when rejecting early', async () => {
-  const { plugin } = makePlugin();
-  const uploadRoute = findRoute(plugin, '_upload', 'POST');
-  let cancelled = false;
-  const bodyStream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new Uint8Array([1]));
-    },
-    cancel() {
-      cancelled = true;
-    },
-  });
-  const res = await uploadRoute.handler(makeCtx({
-    method: 'POST',
-    requestUrl: 'http://localhost/admin/fs-storage/_upload?token=garbage',
-    bodyStream,
-  })) as Response;
-  assertEquals(res.status, 403);
-  // Cancellation is fire-and-forget; give the microtask a beat to land.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  assertEquals(cancelled, true);
-});
+// NOTE: early-reject cancellation of the unread body stream is owned by
+// dispatch now — covered in packages/cms/tests/plugin_route_body_size_test.ts.
 
 Deno.test('routes: _upload rejects a size mismatch', async () => {
   const { plugin } = makePlugin();

--- a/packages/plugins/fs-storage/tests/routes_test.ts
+++ b/packages/plugins/fs-storage/tests/routes_test.ts
@@ -320,6 +320,28 @@ Deno.test('disk adapter: put streams to disk and enforces expectedSize', async (
   });
 });
 
+Deno.test('disk adapter: sequential puts both commit (memoized temp dir)', async () => {
+  await withDiskDir(async (dir) => {
+    const fs = createDiskFsAdapter(dir);
+
+    // The staging dir is created once and memoized; a second put must reuse
+    // it and still land both files under their final keys.
+    await fs.put('posts/image/1/a.bin', new Uint8Array([1, 2]));
+    await fs.put('posts/image/1/b.bin', streamOf(new Uint8Array([3, 4, 5])), {
+      expectedSize: 3,
+    });
+
+    assertEquals(
+      await Deno.readFile(keyToPath(dir, 'posts/image/1/a.bin')),
+      new Uint8Array([1, 2]),
+    );
+    assertEquals(
+      await Deno.readFile(keyToPath(dir, 'posts/image/1/b.bin')),
+      new Uint8Array([3, 4, 5]),
+    );
+  });
+});
+
 Deno.test('disk adapter: put / get / delete / list round-trip', async () => {
   await withDiskDir(async (dir) => {
     const fs = createDiskFsAdapter(dir);

--- a/packages/plugins/fs-storage/types.ts
+++ b/packages/plugins/fs-storage/types.ts
@@ -98,6 +98,18 @@ export interface FsStoragePluginOptions {
   maxUploadBytes?: number;
 
   /**
+   * Resolve each stored key's real path and reject it if a symlink under
+   * `rootDir` redirects it outside (one extra `realpath` syscall per file
+   * operation). Applies only to the default disk adapter — ignored when a
+   * custom {@link FsStoragePluginOptions.fs} adapter is provided. Turn off
+   * only when `rootDir` is a directory your app exclusively controls and you
+   * intentionally place symlinks inside it. See SECURITY.md.
+   *
+   * @default true
+   */
+  symlinkContainment?: boolean;
+
+  /**
    * Custom filesystem backend. Defaults to a disk-backed adapter rooted at
    * {@link FsStoragePluginOptions.rootDir}. Inject an in-memory adapter for
    * tests or an alternative backend for custom storage.

--- a/packages/plugins/fs-storage/types.ts
+++ b/packages/plugins/fs-storage/types.ts
@@ -74,8 +74,8 @@ export interface FsStoragePluginOptions {
    * own serving route is bypassed.
    *
    * ⚠️ A raw static mount serves bytes **without** the CMS row/column policy
-   * checks that the `/files/` route enforces. Only set this for buckets that
-   * are safe to expose publicly.
+   * checks that the `/files/` route enforces. Only set this for directories
+   * that are safe to expose publicly.
    *
    * @example 'https://cdn.example.com/files'
    */

--- a/packages/plugins/s3-storage/README.md
+++ b/packages/plugins/s3-storage/README.md
@@ -6,7 +6,7 @@ S3-compatible storage plugin for HotSauce CMS. Enables direct browser-to-S3 uplo
 
 - **Direct uploads** — Files go straight from browser to S3 (no server bottleneck)
 - **Presigned URLs** — Secure, time-limited upload/download URLs using AWS Signature V4
-- **Policy-aware downloads** — Respects row/column policies for file access control
+- **Policy-aware downloads** — Presigned downloads respect row/column policies for file access control (see the [`cdnBaseUrl` caveat](#policy-integration))
 - **Multi-provider** — Works with AWS S3, MinIO, Cloudflare R2, Backblaze B2, DigitalOcean Spaces
 - **Zero dependencies** — Pure Web Crypto API implementation (no AWS SDK)
 
@@ -70,17 +70,18 @@ The plugin automatically configures `connectSrc` for its upload page via route-l
 
 ## Configuration Options
 
-| Option            | Type                 | Required | Description                                            |
-| ----------------- | -------------------- | -------- | ------------------------------------------------------ |
-| `basePath`        | `string`             | Yes      | CMS base path (e.g., `/admin`)                         |
-| `endpoint`        | `string`             | Yes      | S3 endpoint URL                                        |
-| `region`          | `string`             | Yes      | AWS region (e.g., `us-east-1`)                         |
-| `bucket`          | `string \| Function` | Yes      | Bucket name or function for dynamic routing            |
-| `accessKeyId`     | `string`             | Yes      | AWS access key                                         |
-| `secretAccessKey` | `string`             | Yes      | AWS secret key                                         |
-| `storageId`       | `string`             | No       | Storage ID (default: `'s3'`)                           |
-| `publicEndpoint`  | `string`             | No       | Browser-facing endpoint (if different from `endpoint`) |
-| `expirySeconds`   | `number`             | No       | Presigned URL expiry in seconds (default: `900`)       |
+| Option            | Type                 | Required | Description                                                                                                                    |
+| ----------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `basePath`        | `string`             | Yes      | CMS base path (e.g., `/admin`)                                                                                                 |
+| `endpoint`        | `string`             | Yes      | S3 endpoint URL                                                                                                                |
+| `region`          | `string`             | Yes      | AWS region (e.g., `us-east-1`)                                                                                                 |
+| `bucket`          | `string \| Function` | Yes      | Bucket name or function for dynamic routing                                                                                    |
+| `accessKeyId`     | `string`             | Yes      | AWS access key                                                                                                                 |
+| `secretAccessKey` | `string`             | Yes      | AWS secret key                                                                                                                 |
+| `storageId`       | `string`             | No       | Storage ID (default: `'s3'`)                                                                                                   |
+| `publicEndpoint`  | `string`             | No       | Browser-facing endpoint (if different from `endpoint`)                                                                         |
+| `expirySeconds`   | `number`             | No       | Presigned URL expiry in seconds (default: `900`)                                                                               |
+| `cdnBaseUrl`      | `string`             | No       | Serve downloads via a CDN. ⚠️ Emits **unsigned, non-expiring** URLs — see the [Policy Integration caveat](#policy-integration) |
 
 ## Local Development with MinIO
 
@@ -286,6 +287,14 @@ policies: {
   media: ownedBy(schema.media, 'userId'),
 }
 ```
+
+> ⚠️ **`cdnBaseUrl` caveat.** Policy is enforced at the `/files/` route each
+> time it issues a download URL. The default presigned URL is signed and
+> expires, so a leaked link stops working. A `cdnBaseUrl` URL is **unsigned and
+> non-expiring**, so once issued it is permanent and shareable and bypasses
+> policy on later fetches. Use it for public assets, or ensure the CDN enforces
+> access itself (signed cookies / a private distribution). See
+> [`cdnBaseUrl`](#configuration-options).
 
 ### CORS Configuration
 

--- a/packages/plugins/s3-storage/README.md
+++ b/packages/plugins/s3-storage/README.md
@@ -12,9 +12,32 @@ S3-compatible storage plugin for HotSauce CMS. Enables direct browser-to-S3 uplo
 
 ## Installation
 
+**Deno / JSR** — the plugin ships as part of the `@hotsauce/plugins` package:
+
+```bash
+deno add jsr:@hotsauce/plugins
+```
+
 ```ts
 import { createS3StoragePlugin } from '@hotsauce/plugins/s3-storage';
 ```
+
+**Node / npm** — published standalone as
+[`@hotsauce/plugins-s3-storage`](https://www.npmjs.com/package/@hotsauce/plugins-s3-storage)
+(note the different import specifier):
+
+```bash
+npm install @hotsauce/plugins-s3-storage
+```
+
+```ts
+import { createS3StoragePlugin } from '@hotsauce/plugins-s3-storage';
+```
+
+Sub-exports follow the same shape on both registries: types at
+`@hotsauce/plugins/s3-storage/types` (JSR) /
+`@hotsauce/plugins-s3-storage/types` (npm), and the standalone SigV4 signing
+utilities at `.../signing`.
 
 ## Basic Usage
 

--- a/packages/plugins/s3-storage/README.md
+++ b/packages/plugins/s3-storage/README.md
@@ -294,7 +294,9 @@ policies: {
 > non-expiring**, so once issued it is permanent and shareable and bypasses
 > policy on later fetches. Use it for public assets, or ensure the CDN enforces
 > access itself (signed cookies / a private distribution). See
-> [`cdnBaseUrl`](#configuration-options).
+> [`cdnBaseUrl`](#configuration-options). Per-object signed CDN URLs (with
+> expiry) are on the roadmap —
+> [#91](https://github.com/hotsauce-team/hotsauce/issues/91).
 
 ### CORS Configuration
 

--- a/packages/plugins/s3-storage/mod.ts
+++ b/packages/plugins/s3-storage/mod.ts
@@ -203,6 +203,15 @@ function assertSafeKey(key: string): void {
   if (/[\x00-\x1f\x7f]/.test(key)) {
     throw new Error('Invalid storage key: control character');
   }
+  // Reject percent-encoding. Keys are minted from a restricted charset and
+  // never contain '%'; it is only meaningful as an encoded byte, which a URL
+  // consumer fronting downloads (e.g. a CDN behind `cdnBaseUrl`) may decode
+  // into a separator or dot-segment (%2f -> '/', %2e -> '.'), smuggling
+  // traversal past the literal checks above. The `..`/segment checks below run
+  // on the raw key, so reject the encoded form at the source.
+  if (key.includes('%')) {
+    throw new Error(`Invalid storage key: percent-encoding in "${key}"`);
+  }
   const segments = key.split('/');
   for (const segment of segments) {
     if (segment === '' || segment === '.' || segment === '..') {

--- a/packages/plugins/s3-storage/mod.ts
+++ b/packages/plugins/s3-storage/mod.ts
@@ -312,13 +312,16 @@ function createStorageProvider(options: ResolvedS3Options): StorageProvider {
         })
         : options.bucket;
 
-      // If CDN is configured, use it for download URLs
+      // If CDN is configured, serve downloads through it.
       if (options.cdnBaseUrl) {
-        // CDN URLs don't need signing (CDN handles auth via origin). Build
-        // via the URL API so key encoding matches the presigned branch
-        // (buildObjectUrl): unsafe characters are encoded, but existing %XX
-        // escapes are preserved — a pre-encoded legacy key addresses the
-        // same object on both branches instead of being double-encoded.
+        // NOTE: this returns a BARE, unsigned URL — access control is delegated
+        // entirely to the CDN. Safe only when the objects are public or the CDN
+        // gates them itself (e.g. signed cookies / a private distribution);
+        // otherwise it bypasses the CMS row/column policy the /files/ route
+        // enforced before redirecting here. See `cdnBaseUrl` in types.ts.
+        // Build via the URL API so key encoding matches the presigned branch
+        // (buildObjectUrl): unsafe characters are encoded and existing %XX
+        // escapes preserved — though assertSafeKey above already rejects '%'.
         const url = new URL(options.cdnBaseUrl);
         url.pathname = `${url.pathname.replace(/\/+$/, '')}/${ctx.key}`;
         return url.toString();

--- a/packages/plugins/s3-storage/mod.ts
+++ b/packages/plugins/s3-storage/mod.ts
@@ -211,11 +211,6 @@ function assertSafeKey(key: string): void {
   }
 }
 
-/** Build the relative URL path for a key, segment-encoded. */
-function encodeKeyPath(key: string): string {
-  return key.split('/').map(encodeURIComponent).join('/');
-}
-
 // ─────────────────────────────────────────────────────────────
 // Storage Provider Implementation
 // ─────────────────────────────────────────────────────────────
@@ -310,10 +305,14 @@ function createStorageProvider(options: ResolvedS3Options): StorageProvider {
 
       // If CDN is configured, use it for download URLs
       if (options.cdnBaseUrl) {
-        // CDN URLs don't need signing (CDN handles auth via origin)
-        return `${options.cdnBaseUrl.replace(/\/+$/, '')}/${
-          encodeKeyPath(ctx.key)
-        }`;
+        // CDN URLs don't need signing (CDN handles auth via origin). Build
+        // via the URL API so key encoding matches the presigned branch
+        // (buildObjectUrl): unsafe characters are encoded, but existing %XX
+        // escapes are preserved — a pre-encoded legacy key addresses the
+        // same object on both branches instead of being double-encoded.
+        const url = new URL(options.cdnBaseUrl);
+        url.pathname = `${url.pathname.replace(/\/+$/, '')}/${ctx.key}`;
+        return url.toString();
       }
 
       // Build object URL using publicEndpoint (browser-facing)

--- a/packages/plugins/s3-storage/mod.ts
+++ b/packages/plugins/s3-storage/mod.ts
@@ -129,6 +129,7 @@ export function validatePresignRequest(
     const patterns = accept.split(',').map((p) => p.trim().toLowerCase());
     const type = body.contentType.toLowerCase();
     const matched = patterns.some((pattern) => {
+      if (pattern === '*/*') return true;
       if (pattern === type) return true;
       if (pattern.endsWith('/*')) {
         return type.startsWith(pattern.slice(0, -1));
@@ -170,6 +171,49 @@ function generateObjectKey(
   const safeFilename = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
   // Use shared prefix from core to ensure consistency with key validation
   return `${getFileKeyPrefix(table, column, recordId)}${uuid}-${safeFilename}`;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Key safety
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate that a storage key is safe to embed in a URL path.
+ *
+ * `isValidFileKey` (core) checks that a key carries the right
+ * `{table}/{column}/{recordId}/` prefix, but it does NOT guard against path
+ * traversal. This does: it rejects absolute paths, backslashes, `.`/`..`
+ * segments, empty segments, and control characters — so a tampered or
+ * malicious key can never escape the CDN base or bucket prefix.
+ *
+ * @throws Error if the key is unsafe.
+ */
+function assertSafeKey(key: string): void {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('Invalid storage key: empty');
+  }
+  // No absolute paths, no Windows drive letters, no backslashes.
+  if (key.startsWith('/') || key.startsWith('\\') || /^[a-zA-Z]:/.test(key)) {
+    throw new Error(`Invalid storage key: absolute path "${key}"`);
+  }
+  if (key.includes('\\')) {
+    throw new Error(`Invalid storage key: backslash in "${key}"`);
+  }
+  // deno-lint-ignore no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(key)) {
+    throw new Error('Invalid storage key: control character');
+  }
+  const segments = key.split('/');
+  for (const segment of segments) {
+    if (segment === '' || segment === '.' || segment === '..') {
+      throw new Error(`Invalid storage key: unsafe segment in "${key}"`);
+    }
+  }
+}
+
+/** Build the relative URL path for a key, segment-encoded. */
+function encodeKeyPath(key: string): string {
+  return key.split('/').map(encodeURIComponent).join('/');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -248,6 +292,11 @@ function createStorageProvider(options: ResolvedS3Options): StorageProvider {
      * Generate a signed GET URL for downloads.
      */
     async signDownloadUrl(ctx: SignDownloadContext): Promise<string> {
+      // Core's isValidFileKey only validates the key prefix — reject
+      // traversal/unsafe keys here before either branch links or signs them
+      // (mirrors fs-storage's signDownloadUrl).
+      assertSafeKey(ctx.key);
+
       const bucket = typeof options.bucket === 'function'
         ? options.bucket({
           request: ctx.request ?? new Request('https://internal'),
@@ -262,7 +311,9 @@ function createStorageProvider(options: ResolvedS3Options): StorageProvider {
       // If CDN is configured, use it for download URLs
       if (options.cdnBaseUrl) {
         // CDN URLs don't need signing (CDN handles auth via origin)
-        return `${options.cdnBaseUrl}/${ctx.key}`;
+        return `${options.cdnBaseUrl.replace(/\/+$/, '')}/${
+          encodeKeyPath(ctx.key)
+        }`;
       }
 
       // Build object URL using publicEndpoint (browser-facing)

--- a/packages/plugins/s3-storage/tests/routes_test.ts
+++ b/packages/plugins/s3-storage/tests/routes_test.ts
@@ -641,12 +641,25 @@ Deno.test('listObjects: single page (not truncated) makes one request', async ()
 // signDownloadUrl: key safety + CDN URL building
 // ─────────────────────────────────────────────────────────────
 
-Deno.test('signDownloadUrl: CDN branch trims trailing slashes and segment-encodes the key', async () => {
+Deno.test('signDownloadUrl: CDN branch trims trailing slashes and encodes the key', async () => {
   const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com/' });
 
   const url = await provider.signDownloadUrl!({
     storage: 's3',
     key: 'media/file/1/a b.png',
+  });
+  assertEquals(url, 'https://cdn.example.com/media/file/1/a%20b.png');
+});
+
+Deno.test('signDownloadUrl: CDN branch does not double-encode a pre-encoded key', async () => {
+  // Key encoding must match the presigned branch (URL pathname semantics):
+  // an existing %XX escape is preserved, so a legacy pre-encoded key
+  // addresses the same object on both branches.
+  const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com' });
+
+  const url = await provider.signDownloadUrl!({
+    storage: 's3',
+    key: 'media/file/1/a%20b.png',
   });
   assertEquals(url, 'https://cdn.example.com/media/file/1/a%20b.png');
 });

--- a/packages/plugins/s3-storage/tests/routes_test.ts
+++ b/packages/plugins/s3-storage/tests/routes_test.ts
@@ -6,9 +6,9 @@
  * - Route body: POST body is passed to plugin route handlers
  */
 
-import { assertEquals, assertStringIncludes } from '@std/assert';
+import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
 import { buildObjectUrl, presignUrl } from '../sigv4.ts';
-import { validatePresignRequest } from '../mod.ts';
+import { createS3StoragePlugin, validatePresignRequest } from '../mod.ts';
 
 // ─────────────────────────────────────────────────────────────
 // PublicEndpoint Tests
@@ -375,6 +375,14 @@ Deno.test('presign validation: wildcard */* accepts anything', () => {
   assertEquals(result, null);
 });
 
+Deno.test('presign validation: */* inside an accept list matches any type', () => {
+  const result = validatePresignRequest(
+    { filename: 'photo.png', contentType: 'image/png', size: 1000 },
+    { file: { accept: 'application/pdf,*/*' } },
+  );
+  assertEquals(result, null);
+});
+
 Deno.test('presign validation: no config means no restrictions', () => {
   const body = {
     filename: 'huge.bin',
@@ -635,4 +643,60 @@ Deno.test('listObjects: single page (not truncated) makes one request', async ()
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+// ─────────────────────────────────────────────────────────────
+// signDownloadUrl: key safety + CDN URL building
+// ─────────────────────────────────────────────────────────────
+
+function makeProvider(extra: Record<string, unknown> = {}) {
+  const plugin = createS3StoragePlugin({
+    endpoint: 'http://localhost:9000',
+    region: 'us-east-1',
+    bucket: 'test-bucket',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+    urlStyle: 'path',
+    basePath: '/admin',
+    ...extra,
+  });
+  return plugin.storageProvider!;
+}
+
+Deno.test('signDownloadUrl: CDN branch trims trailing slashes and segment-encodes the key', async () => {
+  const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com/' });
+
+  const url = await provider.signDownloadUrl!({
+    storage: 's3',
+    key: 'media/file/1/a b.png',
+  });
+  assertEquals(url, 'https://cdn.example.com/media/file/1/a%20b.png');
+});
+
+Deno.test('signDownloadUrl: CDN branch rejects a traversal key', async () => {
+  const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com' });
+
+  await assertRejects(
+    () =>
+      provider.signDownloadUrl!({
+        storage: 's3',
+        key: 'media/file/1/../../etc/passwd',
+      }),
+    Error,
+    'Invalid storage key',
+  );
+});
+
+Deno.test('signDownloadUrl: presign branch rejects a traversal key', async () => {
+  const provider = makeProvider();
+
+  await assertRejects(
+    () =>
+      provider.signDownloadUrl!({
+        storage: 's3',
+        key: 'media/file/1/../../etc/passwd',
+      }),
+    Error,
+    'Invalid storage key',
+  );
 });

--- a/packages/plugins/s3-storage/tests/routes_test.ts
+++ b/packages/plugins/s3-storage/tests/routes_test.ts
@@ -499,6 +499,21 @@ Deno.test('presign validation: uppercase extension is validated', () => {
   assertEquals(result, null);
 });
 
+/** Storage provider off a plugin built with the standard test options. */
+function makeProvider(extra: Record<string, unknown> = {}) {
+  const plugin = createS3StoragePlugin({
+    endpoint: 'http://localhost:9000',
+    region: 'us-east-1',
+    bucket: 'test-bucket',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+    urlStyle: 'path',
+    basePath: '/admin',
+    ...extra,
+  });
+  return plugin.storageProvider!;
+}
+
 // ─────────────────────────────────────────────────────────────
 // ListObjectsV2 Pagination Tests
 // ─────────────────────────────────────────────────────────────
@@ -559,19 +574,7 @@ Deno.test('listObjects: paginates through multiple pages', async () => {
   }) as typeof fetch;
 
   try {
-    // Import and create the storage provider
-    const { createS3StoragePlugin } = await import('../mod.ts');
-    const plugin = createS3StoragePlugin({
-      endpoint: 'http://localhost:9000',
-      region: 'us-east-1',
-      bucket: 'test-bucket',
-      accessKeyId: 'test-key',
-      secretAccessKey: 'test-secret',
-      urlStyle: 'path',
-      basePath: '/admin',
-    });
-
-    const provider = plugin.storageProvider!;
+    const provider = makeProvider();
     const results = await provider.listObjects!('prefix/');
 
     // Should have made 2 fetch calls (2 pages)
@@ -622,18 +625,7 @@ Deno.test('listObjects: single page (not truncated) makes one request', async ()
   }) as typeof fetch;
 
   try {
-    const { createS3StoragePlugin } = await import('../mod.ts');
-    const plugin = createS3StoragePlugin({
-      endpoint: 'http://localhost:9000',
-      region: 'us-east-1',
-      bucket: 'test-bucket',
-      accessKeyId: 'test-key',
-      secretAccessKey: 'test-secret',
-      urlStyle: 'path',
-      basePath: '/admin',
-    });
-
-    const provider = plugin.storageProvider!;
+    const provider = makeProvider();
     const results = await provider.listObjects!('prefix/');
 
     // Only 1 fetch call for non-truncated response
@@ -648,20 +640,6 @@ Deno.test('listObjects: single page (not truncated) makes one request', async ()
 // ─────────────────────────────────────────────────────────────
 // signDownloadUrl: key safety + CDN URL building
 // ─────────────────────────────────────────────────────────────
-
-function makeProvider(extra: Record<string, unknown> = {}) {
-  const plugin = createS3StoragePlugin({
-    endpoint: 'http://localhost:9000',
-    region: 'us-east-1',
-    bucket: 'test-bucket',
-    accessKeyId: 'test-key',
-    secretAccessKey: 'test-secret',
-    urlStyle: 'path',
-    basePath: '/admin',
-    ...extra,
-  });
-  return plugin.storageProvider!;
-}
 
 Deno.test('signDownloadUrl: CDN branch trims trailing slashes and segment-encodes the key', async () => {
   const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com/' });

--- a/packages/plugins/s3-storage/tests/routes_test.ts
+++ b/packages/plugins/s3-storage/tests/routes_test.ts
@@ -651,19 +651,6 @@ Deno.test('signDownloadUrl: CDN branch trims trailing slashes and encodes the ke
   assertEquals(url, 'https://cdn.example.com/media/file/1/a%20b.png');
 });
 
-Deno.test('signDownloadUrl: CDN branch does not double-encode a pre-encoded key', async () => {
-  // Key encoding must match the presigned branch (URL pathname semantics):
-  // an existing %XX escape is preserved, so a legacy pre-encoded key
-  // addresses the same object on both branches.
-  const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com' });
-
-  const url = await provider.signDownloadUrl!({
-    storage: 's3',
-    key: 'media/file/1/a%20b.png',
-  });
-  assertEquals(url, 'https://cdn.example.com/media/file/1/a%20b.png');
-});
-
 Deno.test('signDownloadUrl: CDN branch rejects a traversal key', async () => {
   const provider = makeProvider({ cdnBaseUrl: 'https://cdn.example.com' });
 
@@ -690,4 +677,22 @@ Deno.test('signDownloadUrl: presign branch rejects a traversal key', async () =>
     Error,
     'Invalid storage key',
   );
+});
+
+Deno.test('signDownloadUrl: rejects percent-encoded traversal (CDN-decode smuggling)', async () => {
+  // '%2e%2e%2f' decodes to '../' at a CDN that resolves the path; reject it at
+  // the key validator so it never reaches the CDN URL literally.
+  const key = 'media/file/1/%2e%2e%2f%2e%2e%2fetc/passwd';
+  for (
+    const provider of [
+      makeProvider({ cdnBaseUrl: 'https://cdn.example.com' }),
+      makeProvider(),
+    ]
+  ) {
+    await assertRejects(
+      () => provider.signDownloadUrl!({ storage: 's3', key }),
+      Error,
+      'percent-encoding',
+    );
+  }
 });

--- a/packages/plugins/s3-storage/types.ts
+++ b/packages/plugins/s3-storage/types.ts
@@ -170,6 +170,8 @@ export interface S3StoragePluginOptions {
    * This option emits a **bare** URL; it does not generate per-object CDN
    * *signed URLs*, so a CDN configured to require signed URLs (rather than
    * cookies) will reject it. Use signed cookies or a public/gated distribution.
+   * (Per-object signed CDN URLs are on the roadmap — see
+   * https://github.com/hotsauce-team/hotsauce/issues/91.)
    *
    * @example 'https://cdn.example.com'
    */

--- a/packages/plugins/s3-storage/types.ts
+++ b/packages/plugins/s3-storage/types.ts
@@ -150,9 +150,26 @@ export interface S3StoragePluginOptions {
   publicEndpoint?: string;
 
   /**
-   * Optional CDN base URL for serving files.
-   * When set, download URLs use this instead of S3 endpoint.
-   * Provider-agnostic - works with any CDN (CloudFront, Fastly, etc.).
+   * Optional CDN base URL for serving downloads. When set, `signDownloadUrl`
+   * returns `${cdnBaseUrl}/${key}` instead of a presigned S3 URL.
+   * Provider-agnostic — works with any CDN (CloudFront, Fastly, R2, …).
+   *
+   * ⚠️ Unlike the default presigned downloads (SigV4-signed and short-lived via
+   * `expirySeconds`), a CDN URL here is **unsigned and non-expiring**. The
+   * `/files/` route still checks row/column policy before redirecting, but the
+   * issued URL is permanent and shareable, so it bypasses that policy on any
+   * later fetch. Set this only when either:
+   * - the objects are safe to expose publicly (public assets — edge caching is
+   *   the goal), or
+   * - the CDN enforces access control itself, e.g. **signed cookies** scoped to
+   *   the session (CloudFront/Cloudflare signed cookies) or a private
+   *   distribution, so a bare object URL is still gated at the CDN. Note this
+   *   gates at the CDN's granularity (typically path/session), which is coarser
+   *   than the CMS's per-record policy.
+   *
+   * This option emits a **bare** URL; it does not generate per-object CDN
+   * *signed URLs*, so a CDN configured to require signed URLs (rather than
+   * cookies) will reject it. Use signed cookies or a public/gated distribution.
    *
    * @example 'https://cdn.example.com'
    */

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -429,9 +429,14 @@ export interface PluginRouteContext {
    * Lifecycle: dispatch owns cleanup. After the handler settles, the CMS
    * cancels `bodyStream` if it is not locked, aborting the client transfer.
    * Handlers that consume the body must begin reading (acquire the stream's
-   * lock) before returning — do not stash the stream for post-response
-   * reading. Handlers that reject a request early can simply return the
-   * error Response; dispatch cancels the unread stream for them.
+   * lock via `getReader()`, `pipeTo()`, or `for await`) before returning —
+   * do not stash the stream for post-response reading, and do NOT return
+   * `bodyStream` (or a stream piped from it) as a Response body:
+   * `new Response(stream)` does not lock the stream until the response is
+   * serialized, which happens after dispatch's cleanup — the body would be
+   * cancelled before a byte is sent. Handlers that reject a request early
+   * can simply return the error Response; dispatch cancels the unread
+   * stream for them.
    */
   bodyStream?: ReadableStream<Uint8Array>;
   /** Additional route params from pattern matching */

--- a/packages/workers/types.ts
+++ b/packages/workers/types.ts
@@ -425,6 +425,13 @@ export interface PluginRouteContext {
    * NOTE: a `ReadableStream` is not serializable, so this field makes the
    * context *not* fully serializable. It is therefore in-process only and is
    * never populated for (or sent to) Worker render routes.
+   *
+   * Lifecycle: dispatch owns cleanup. After the handler settles, the CMS
+   * cancels `bodyStream` if it is not locked, aborting the client transfer.
+   * Handlers that consume the body must begin reading (acquire the stream's
+   * lock) before returning — do not stash the stream for post-response
+   * reading. Handlers that reject a request early can simply return the
+   * error Response; dispatch cancels the unread stream for them.
    */
   bodyStream?: ReadableStream<Uint8Array>;
   /** Additional route params from pattern matching */

--- a/scripts/npm/build_npm.ts
+++ b/scripts/npm/build_npm.ts
@@ -1,7 +1,7 @@
 /**
  * Build npm packages using dnt (Deno to Node transform)
  *
- * Usage: deno run -A scripts/build_npm.ts [version]
+ * Usage: deno run -A scripts/npm/build_npm.ts [version]
  *
  * This script builds @hotsauce/core, @hotsauce/ui, @hotsauce/auth, @hotsauce/cms,
  * @hotsauce/plugins-fs-storage, and @hotsauce/plugins-s3-storage packages for

--- a/scripts/npm/build_npm.ts
+++ b/scripts/npm/build_npm.ts
@@ -4,8 +4,9 @@
  * Usage: deno run -A scripts/build_npm.ts [version]
  *
  * This script builds @hotsauce/core, @hotsauce/ui, @hotsauce/auth, @hotsauce/cms,
- * and @hotsauce/plugins-fs-storage packages for npm distribution. Tests are NOT
- * run during build - use npm-tests/ for Node.js e2e testing.
+ * @hotsauce/plugins-fs-storage, and @hotsauce/plugins-s3-storage packages for
+ * npm distribution. Tests are NOT run during build - use npm-tests/ for Node.js
+ * e2e testing.
  */
 
 import { build, emptyDir } from 'jsr:@deno/dnt@0.42.3';
@@ -42,7 +43,7 @@ const repoUrlShort = 'https://github.com/hotsauce-team/hotsauce';
 // ─────────────────────────────────────────────────────────────
 // Build @hotsauce/core
 // ─────────────────────────────────────────────────────────────
-console.log('\n[1/5] Building @hotsauce/core...');
+console.log('\n[1/6] Building @hotsauce/core...');
 await emptyDir('./npm/core');
 await build({
   ...sharedOptions,
@@ -77,7 +78,7 @@ await build({
 // ─────────────────────────────────────────────────────────────
 // Build @hotsauce/ui
 // ─────────────────────────────────────────────────────────────
-console.log('\n[2/5] Building @hotsauce/ui...');
+console.log('\n[2/6] Building @hotsauce/ui...');
 await emptyDir('./npm/ui');
 await build({
   ...sharedOptions,
@@ -108,7 +109,7 @@ await build({
 // ─────────────────────────────────────────────────────────────
 // Build @hotsauce/auth
 // ─────────────────────────────────────────────────────────────
-console.log('\n[3/5] Building @hotsauce/auth...');
+console.log('\n[3/6] Building @hotsauce/auth...');
 await emptyDir('./npm/auth');
 await build({
   ...sharedOptions,
@@ -138,7 +139,7 @@ await build({
 // ─────────────────────────────────────────────────────────────
 // Build @hotsauce/cms
 // ─────────────────────────────────────────────────────────────
-console.log('\n[4/5] Building @hotsauce/cms...');
+console.log('\n[4/6] Building @hotsauce/cms...');
 await emptyDir('./npm/cms');
 await build({
   ...sharedOptions,
@@ -185,7 +186,7 @@ await build({
 // place in a Node build. This package mainly exists so npm-tests/ can exercise
 // the disk adapter's node:fs/promises branch on real Node.
 // ─────────────────────────────────────────────────────────────
-console.log('\n[5/5] Building @hotsauce/plugins-fs-storage...');
+console.log('\n[5/6] Building @hotsauce/plugins-fs-storage...');
 await emptyDir('./npm/plugins-fs-storage');
 await build({
   ...sharedOptions,
@@ -236,5 +237,71 @@ await build({
   },
 });
 
+// ─────────────────────────────────────────────────────────────
+// Build @hotsauce/plugins-s3-storage
+//
+// Scoped to the s3-storage plugin only, for the same reason as fs-storage
+// above: the parent @hotsauce/plugins package pulls in browser-targeting
+// puck/React code. Pure fetch + Web Crypto, so no shims are needed.
+// ─────────────────────────────────────────────────────────────
+console.log('\n[6/6] Building @hotsauce/plugins-s3-storage...');
+await emptyDir('./npm/plugins-s3-storage');
+await build({
+  ...sharedOptions,
+  entryPoints: [
+    './packages/plugins/s3-storage/mod.ts',
+    {
+      name: './types',
+      path: './packages/plugins/s3-storage/types.ts',
+    },
+    {
+      // Standalone SigV4 utilities (mirrors the JSR ./s3-storage/signing export)
+      name: './signing',
+      path: './packages/plugins/s3-storage/signing.ts',
+    },
+  ],
+  outDir: './npm/plugins-s3-storage',
+  package: {
+    name: '@hotsauce/plugins-s3-storage',
+    version,
+    description:
+      'S3-compatible object storage plugin for @hotsauce/cms (AWS S3, MinIO, R2, ...)',
+    license: 'MIT',
+    repository: {
+      type: 'git',
+      url: repoUrl,
+      directory: 'packages/plugins/s3-storage',
+    },
+    bugs: { url: `${repoUrlShort}/issues` },
+    engines: { node: '>=20.0.0' },
+  },
+  mappings: {
+    [`${baseUrl}/packages/core/mod.ts`]: {
+      name: '@hotsauce/core',
+      version: `>=${version}`,
+    },
+    [`${baseUrl}/packages/ui/mod.ts`]: {
+      name: '@hotsauce/ui',
+      version: `>=${version}`,
+    },
+    [`${baseUrl}/packages/cms/mod.ts`]: {
+      name: '@hotsauce/cms',
+      version: `>=${version}`,
+    },
+  },
+  postBuild() {
+    Deno.copyFileSync(
+      'packages/plugins/LICENSE',
+      'npm/plugins-s3-storage/LICENSE',
+    );
+    Deno.copyFileSync(
+      'packages/plugins/s3-storage/README.md',
+      'npm/plugins-s3-storage/README.md',
+    );
+  },
+});
+
 console.log('\n✅ All packages built successfully!');
-console.log('   npm/core, npm/ui, npm/auth, npm/cms, npm/plugins-fs-storage');
+console.log(
+  '   npm/core, npm/ui, npm/auth, npm/cms, npm/plugins-fs-storage, npm/plugins-s3-storage',
+);

--- a/scripts/npm/test-npm.sh
+++ b/scripts/npm/test-npm.sh
@@ -62,6 +62,7 @@ cp -r "$PROJECT_DIR/npm/ui" "$TEMP_DIR/packages/"
 cp -r "$PROJECT_DIR/npm/auth" "$TEMP_DIR/packages/"
 cp -r "$PROJECT_DIR/npm/cms" "$TEMP_DIR/packages/"
 cp -r "$PROJECT_DIR/npm/plugins-fs-storage" "$TEMP_DIR/packages/"
+cp -r "$PROJECT_DIR/npm/plugins-s3-storage" "$TEMP_DIR/packages/"
 
 # Step 2a: Install dependencies (needs network)
 echo "Installing dependencies..."


### PR DESCRIPTION
Follow-ups from the PR #85 review, tracked in #89. Per maintainer decision, **all deduplication items in #89 are intentionally descoped** — this PR delivers the non-dedup items only.

## What's included

- **fix(s3-storage): accept-list wildcard + download-key safety** — the inline accept matcher now matches a `*/*` entry inside a comma-separated list (fixed in place, mirroring `matchesAcceptPattern`), and `signDownloadUrl` asserts key safety before both branches, trims trailing slashes off `cdnBaseUrl`, and segment-encodes the key.
- **feat(cms): dispatch owns `bodyStream` cancellation** — `handlePluginRoute` cancels an unlocked `bodyStream` after the handler settles (`try/finally`), so stream-route handlers can return error responses directly. Contract documented on `PluginRouteContext.bodyStream`; fs-storage's `reject()` wrapper dropped; covered by a handler-consumes / ignores / throws test matrix.
- **perf(fs-storage)** — memoized staging-dir creation in `put()` (one awaited mkdir per upload instead of two, reset-on-failure) and module-level `TextEncoder`/`TextDecoder` in `signing.ts`.
- **build(npm): `@hotsauce/plugins-s3-storage`** — sixth dnt build scoped to the s3-storage sub-path with `./types` and `./signing` sub-exports; copy lists synced in `test-npm.sh` and `node-compat.yml`; new Node smoke suite (presign validation incl. the `*/*`-in-list regression, SigV4 against the AWS example vector, CDN key safety).
- **docs**: matching JSR-vs-npm Installation sections in both plugin READMEs.

## Descoped from #89 (deliberate)

- Shared storage-common extraction (`validatePresignRequest`, `resolveFileConfig`, `safeJsonForHtml`, byte-label formatter, `assertSafeKey` variants, `getVerifiedToken`) — the s3 fixes were applied in place instead.
- HMAC signing unification — verified low overlap: fs `signing.ts` (base64url opaque tokens, memoized `CryptoKey` per secret) and s3 `sigv4.ts` (hex SigV4, derived-key caching) share only the low-level HMAC call.
- Runtime-fork detection dedup — s3 has none (pure fetch/WebCrypto); fs's `denoNs()`/`nodeFs()` is bespoke to disk I/O. The only true duplicate found is `getEnv` (cms `runtime-compat.ts` vs auth `provider.ts`), which can't move without a dependency-direction change — left for a future issue if wanted.
- `tooLarge → 413` triple in `packages/cms/mod.ts` and the data-driven `PACKAGES` array in `build_npm.ts`.

## Verification

- `deno task test`: 1327 passed, 0 failed.
- Node e2e (host build + Docker `node:24`, per the #86 workaround): 19 passed across all six packages, including the new `s3-storage.test.js`.
- `deno publish --dry-run --allow-dirty` on `packages/plugins`: success.
- Pushed manually: this branch touches `.github/workflows/node-compat.yml`, which the issue-agent pipeline cannot push.

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)