### PR TITLE
feat(bench): micro + e2e benchmark suites

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -61,6 +61,9 @@
     "test:watch": "deno test -P --watch",
     "test:drizzle-compat": "deno test -P packages/core/tests/drizzle_compat_test.ts",
     "test:npm": "./scripts/npm/test-npm.sh", // builds + tests in Docker
+    // Benchmarks (see BENCHMARKS.md)
+    "bench": "deno bench -P",
+    "bench:json": "deno bench -P --json",
     // Code quality tasks
     "check": "deno check packages/*/mod.ts",
     "lint": "deno lint",
@@ -102,6 +105,20 @@
       ],
       "env": [
         "CMS_2FA_SECRET",
+        "CMS_CSRF_SECRET",
+        "CMS_JWT_SECRET",
+        "CMS_TESTING"
+      ]
+    }
+  },
+
+  // Benchmark configuration with fine-grained permissions.
+  // E2E handler benches use in-memory node:sqlite, so no wasm/db file reads.
+  "bench": {
+    "include": ["packages/*/benches/"],
+    "permissions": {
+      "read": ["./packages"],
+      "env": [
         "CMS_CSRF_SECRET",
         "CMS_JWT_SECRET",
         "CMS_TESTING"

--- a/packages/auth/benches/jwt_bench.ts
+++ b/packages/auth/benches/jwt_bench.ts
@@ -1,0 +1,35 @@
+// Micro-benchmarks: JWT sign/verify and cookie parsing — verifyJwt runs on
+// every authenticated request. PBKDF2 password hashing and TOTP are
+// deliberately excluded (slow by design / time-window dependent); see
+// BENCHMARKS.md. Run with: deno task bench
+
+import { createJwtPayload, signJwt, verifyJwt } from '../jwt.ts';
+import { createAuthCookie, getTokenFromCookies } from '../cookies.ts';
+
+const secret = 'bench-secret-0123456789abcdef0123456789abcdef';
+const payload = createJwtPayload('42', 'user@example.com', 'admin');
+const token = await signJwt(payload, secret);
+
+Deno.bench('signJwt (HS256)', async () => {
+  await signJwt(payload, secret);
+});
+
+Deno.bench('verifyJwt (HS256)', async () => {
+  await verifyJwt(token, secret);
+});
+
+Deno.bench('createJwtPayload', () => {
+  createJwtPayload('42', 'user@example.com', 'admin');
+});
+
+const request = new Request('http://localhost/admin', {
+  headers: { Cookie: `theme=dark; cms_token=${token}; sidebar=open` },
+});
+
+Deno.bench('getTokenFromCookies: 3-cookie header', () => {
+  getTokenFromCookies(request, 'cms_token');
+});
+
+Deno.bench('createAuthCookie', () => {
+  createAuthCookie('cms_token', token, 3600, '/admin', true);
+});

--- a/packages/auth/deno.jsonc
+++ b/packages/auth/deno.jsonc
@@ -11,7 +11,8 @@
       "LICENSE"
     ],
     "exclude": [
-      "tests/"
+      "tests/",
+      "benches/"
     ]
   }
 }

--- a/packages/cms/benches/bench_helpers.ts
+++ b/packages/cms/benches/bench_helpers.ts
@@ -1,0 +1,172 @@
+// Shared setup for the end-to-end handler benchmarks.
+//
+// The database is an in-memory node:sqlite instance wired to Drizzle through
+// the sqlite-proxy driver, so a full Request→Response cycle measures CMS
+// overhead (routing, auth, policies, validation, HTML rendering) plus a
+// real-but-fast SQL engine — no external services, no wasm startup cost.
+
+import { DatabaseSync } from 'node:sqlite';
+import { drizzle } from 'drizzle-orm/sqlite-proxy';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+
+// Bench secrets (long enough to pass validation)
+export const BENCH_CSRF_SECRET =
+  'bench-csrf-secret-for-benchmarks-min-32-chars';
+export const BENCH_AUTH_SECRET =
+  'bench-auth-secret-must-be-at-least-32-characters';
+
+// ============================================================================
+// Bench schema — mirrors the shapes used by the integration tests
+// ============================================================================
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email', { length: 255 }).notNull().unique(),
+  name: text('name', { length: 100 }).notNull(),
+  bio: text('bio'),
+  isAdmin: integer('is_admin', { mode: 'boolean' }).notNull().default(false),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+});
+
+export const posts = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title', { length: 200 }).notNull(),
+  body: text('body'),
+  authorId: integer('author_id').notNull().references(() => users.id),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+});
+
+export const adminUsers = sqliteTable('admin_users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email', { length: 255 }).notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  role: text('role', { length: 50 }),
+});
+
+export const usersRelations = relations(users, ({ many }) => ({
+  posts: many(posts),
+}));
+
+export const postsRelations = relations(posts, ({ one }) => ({
+  author: one(users, {
+    fields: [posts.authorId],
+    references: [users.id],
+  }),
+}));
+
+export const schema = {
+  users,
+  posts,
+  usersRelations,
+  postsRelations,
+  adminUsers,
+};
+
+// ============================================================================
+// Database setup
+// ============================================================================
+
+// Generic database type, same convention as the integration tests
+// deno-lint-ignore no-explicit-any
+type AnyDb = any;
+
+export interface BenchDbContext {
+  sqlite: DatabaseSync;
+  db: AnyDb;
+}
+
+/**
+ * Create an in-memory SQLite database with the bench tables, exposed to
+ * Drizzle via the sqlite-proxy driver.
+ */
+export function createBenchDb(): BenchDbContext {
+  const sqlite = new DatabaseSync(':memory:');
+
+  const db = drizzle(
+    // deno-lint-ignore require-await
+    async (query: string, params: unknown[], method: string) => {
+      const stmt = sqlite.prepare(query);
+      if (method === 'run') {
+        stmt.run(...(params as never[]));
+        return { rows: [] };
+      }
+      if (method === 'get') {
+        const row = stmt.get(...(params as never[]));
+        // sqlite-proxy expects a single row as an array of values
+        return { rows: row ? Object.values(row) : [] };
+      }
+      // 'all' / 'values': array of value-arrays. node:sqlite returns objects
+      // whose property insertion order matches the SELECT column order.
+      const rows = stmt.all(...(params as never[]));
+      return { rows: rows.map((r) => Object.values(r)) };
+    },
+    { schema },
+  );
+
+  sqlite.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      bio TEXT,
+      is_admin INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      body TEXT,
+      author_id INTEGER NOT NULL REFERENCES users(id),
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE admin_users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      role TEXT
+    );
+  `);
+
+  return { sqlite, db };
+}
+
+/**
+ * Seed users and posts with direct prepared statements (outside any
+ * measured region). Post authors cycle through the seeded users.
+ */
+export function seedData(
+  sqlite: DatabaseSync,
+  counts: { users: number; posts: number },
+): void {
+  const now = Math.floor(Date.now() / 1000);
+
+  const insertUser = sqlite.prepare(
+    'INSERT INTO users (email, name, bio, is_admin, created_at) VALUES (?, ?, ?, ?, ?)',
+  );
+  for (let i = 1; i <= counts.users; i++) {
+    insertUser.run(
+      `user${i}@example.com`,
+      `User ${i}`,
+      i % 3 === 0 ? null : `Bio for user ${i}`,
+      i === 1 ? 1 : 0,
+      now,
+    );
+  }
+
+  const insertPost = sqlite.prepare(
+    'INSERT INTO posts (title, body, author_id, created_at) VALUES (?, ?, ?, ?)',
+  );
+  for (let i = 1; i <= counts.posts; i++) {
+    insertPost.run(
+      `Post ${i}: a title with <markup> & entities`,
+      `Body of post ${i}. `.repeat(10),
+      (i % counts.users) + 1,
+      now,
+    );
+  }
+}

--- a/packages/cms/benches/handler_bench.ts
+++ b/packages/cms/benches/handler_bench.ts
@@ -1,0 +1,177 @@
+// End-to-end handler benchmarks: full Request → Response cycles through
+// createCmsHandler, including body consumption. These are the headline
+// numbers — see BENCHMARKS.md for methodology. Run with: deno task bench
+
+import {
+  createCmsHandler,
+  createJwtPayload,
+  ownedBy,
+  signJwt,
+} from '../mod.ts';
+import type { Handler } from '../types.ts';
+import { PasswordProvider } from '@hotsauce/auth';
+import { generateCsrfToken } from '../csrf.ts';
+import { generateSourceToken, SOURCE } from '../tokens/source.ts';
+import {
+  adminUsers,
+  BENCH_AUTH_SECRET,
+  BENCH_CSRF_SECRET,
+  createBenchDb,
+  posts,
+  schema,
+  seedData,
+} from './bench_helpers.ts';
+
+const { sqlite, db } = createBenchDb();
+seedData(sqlite, { users: 25, posts: 1000 });
+const SEEDED_POSTS = 1000;
+
+// Pure-speed path: no auth, no policies.
+const openHandler = createCmsHandler({
+  csrfSecret: BENCH_CSRF_SECRET,
+  db,
+  schema,
+  basePath: '/admin',
+  auth: 'dangerously-open',
+  policies: 'dangerously-open',
+});
+
+// Honest-overhead path: JWT auth plus row + column policies on posts.
+const policyHandler = createCmsHandler({
+  csrfSecret: BENCH_CSRF_SECRET,
+  db,
+  schema,
+  basePath: '/admin',
+  auth: {
+    secret: BENCH_AUTH_SECRET,
+    provider: new PasswordProvider({ db, usersTable: adminUsers }),
+  },
+  policies: {
+    posts: {
+      row: ownedBy(posts, 'authorId'),
+      columns: {
+        body: { read: () => false },
+      },
+    },
+  },
+});
+
+const authCookie = `cms_token=${await signJwt(
+  createJwtPayload('1'),
+  BENCH_AUTH_SECRET,
+)}`;
+
+function getRequest(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://localhost${path}`, init);
+}
+
+// Pre-flight: fail loudly at load time if any benched route errors, so the
+// benchmarks can never silently measure error pages.
+async function preflight(
+  handler: Handler,
+  request: Request,
+  maxStatus = 299,
+): Promise<void> {
+  const response = await handler(request);
+  const body = await response.text();
+  if (response.status > maxStatus) {
+    throw new Error(
+      `Pre-flight failed: ${request.method} ${request.url} → ${response.status}\n${
+        body.slice(0, 500)
+      }`,
+    );
+  }
+}
+
+await preflight(openHandler, getRequest('/admin'));
+await preflight(openHandler, getRequest('/admin/users'));
+await preflight(openHandler, getRequest('/admin/posts'));
+await preflight(openHandler, getRequest('/admin/posts?limit=100'));
+await preflight(openHandler, getRequest('/admin/posts/1'));
+await preflight(openHandler, getRequest('/admin/posts/1/edit'));
+await preflight(
+  policyHandler,
+  getRequest('/admin/posts', { headers: { Cookie: authCookie } }),
+);
+
+Deno.bench('e2e: GET /admin — dashboard', async () => {
+  const res = await openHandler(getRequest('/admin'));
+  await res.text();
+});
+
+Deno.bench(
+  'e2e: GET /admin/users — list page (25-row table)',
+  { group: 'e2e list page', baseline: true },
+  async () => {
+    const res = await openHandler(getRequest('/admin/users'));
+    await res.text();
+  },
+);
+
+Deno.bench(
+  'e2e: GET /admin/posts — default page of 25 (1,000-row table)',
+  { group: 'e2e list page' },
+  async () => {
+    const res = await openHandler(getRequest('/admin/posts'));
+    await res.text();
+  },
+);
+
+Deno.bench(
+  'e2e: GET /admin/posts?limit=100 — page of 100 (1,000-row table)',
+  { group: 'e2e list page' },
+  async () => {
+    const res = await openHandler(getRequest('/admin/posts?limit=100'));
+    await res.text();
+  },
+);
+
+Deno.bench('e2e: GET /admin/posts/1 — detail page', async () => {
+  const res = await openHandler(getRequest('/admin/posts/1'));
+  await res.text();
+});
+
+Deno.bench('e2e: GET /admin/posts/1/edit — edit form', async () => {
+  const res = await openHandler(getRequest('/admin/posts/1/edit'));
+  await res.text();
+});
+
+Deno.bench(
+  'e2e: GET /admin/posts — list with JWT auth + row/column policies',
+  async () => {
+    const res = await policyHandler(
+      getRequest('/admin/posts', { headers: { Cookie: authCookie } }),
+    );
+    await res.text();
+  },
+);
+
+// Create measures only the handler call (b.start/b.end); token generation
+// happens before the timer and cleanup after, so the table never grows
+// across iterations.
+const deleteCreated = sqlite.prepare('DELETE FROM posts WHERE id > ?');
+
+Deno.bench('e2e: POST /admin/posts/new — create (form submit)', async (b) => {
+  const csrfToken = await generateCsrfToken(BENCH_CSRF_SECRET);
+  const sourceToken = await generateSourceToken(SOURCE.CMS, BENCH_CSRF_SECRET);
+  const form = new FormData();
+  form.append('title', 'Bench post');
+  form.append('body', 'Created during a benchmark iteration.');
+  form.append('authorId', '1');
+  form.append('__cms_csrf', csrfToken);
+  form.append('__cms_source', sourceToken);
+  const request = getRequest('/admin/posts/new', {
+    method: 'POST',
+    body: form,
+  });
+
+  b.start();
+  const res = await openHandler(request);
+  await res.text();
+  b.end();
+
+  if (res.status >= 400) {
+    throw new Error(`create failed with status ${res.status}`);
+  }
+  deleteCreated.run(SEEDED_POSTS);
+});

--- a/packages/cms/benches/policies_bench.ts
+++ b/packages/cms/benches/policies_bench.ts
@@ -1,0 +1,57 @@
+// Micro-benchmarks: row/column policy application — runs on every request
+// when policies are configured. Run with: deno task bench
+
+import { sql } from 'drizzle-orm';
+import { introspectTable } from '@hotsauce/core';
+import { users } from '../../core/tests/fixtures/schema-pg.ts';
+import {
+  buildPolicyWhere,
+  createPolicyContext,
+  filterRecordsColumns,
+} from '../policies/apply.ts';
+
+const usersInfo = introspectTable(users);
+const tenantCondition = sql`tenant_id = ${'tenant-1'}`;
+
+Deno.bench('buildPolicyWhere: pk check + policy condition', () => {
+  buildPolicyWhere(users, usersInfo, '42', tenantCondition);
+});
+
+const request = new Request('http://localhost/admin/users');
+
+Deno.bench('createPolicyContext', () => {
+  createPolicyContext(request, { id: 'user-1', role: 'editor' }, 'form');
+});
+
+// Column filtering scales with row count: strip one hidden column
+// from result sets of 100 and 1,000 rows.
+const columns = usersInfo.columns;
+const readable = columns
+  .filter((c) => c.propertyName !== 'email')
+  .map((c) => c.name);
+
+function makeRecords(count: number): Record<string, unknown>[] {
+  return Array.from({ length: count }, (_, i) =>
+    Object.fromEntries(
+      columns.map((c) => [c.propertyName, `${c.propertyName}-${i}`]),
+    ));
+}
+
+const rows100 = makeRecords(100);
+const rows1000 = makeRecords(1000);
+
+Deno.bench(
+  'filterRecordsColumns: 100 rows',
+  { group: 'column filtering', baseline: true },
+  () => {
+    filterRecordsColumns(rows100, readable, columns);
+  },
+);
+
+Deno.bench(
+  'filterRecordsColumns: 1,000 rows',
+  { group: 'column filtering' },
+  () => {
+    filterRecordsColumns(rows1000, readable, columns);
+  },
+);

--- a/packages/cms/benches/router_bench.ts
+++ b/packages/cms/benches/router_bench.ts
@@ -1,0 +1,53 @@
+// Micro-benchmarks: URL routing and dispatch — runs on every request.
+// Run with: deno task bench
+
+import { introspectSchema } from '@hotsauce/core';
+import * as schema from '../../core/tests/fixtures/schema-pg.ts';
+import { matchPluginRoute, parseRoute, resolveAction } from '../router.ts';
+import type { PluginConfig } from '../plugins/types.ts';
+
+const tables = introspectSchema(schema);
+const basePath = '/admin';
+
+const listUrl = new URL('http://localhost/admin/posts');
+const detailUrl = new URL('http://localhost/admin/posts/42');
+const editUrl = new URL('http://localhost/admin/posts/42/edit');
+const missUrl = new URL('http://localhost/admin/no_such_table');
+
+Deno.bench('parseRoute: list URL', () => {
+  parseRoute(listUrl, basePath, tables);
+});
+
+Deno.bench('parseRoute: detail URL', () => {
+  parseRoute(detailUrl, basePath, tables);
+});
+
+Deno.bench('parseRoute: edit URL', () => {
+  parseRoute(editUrl, basePath, tables);
+});
+
+Deno.bench('parseRoute: unknown table (404)', () => {
+  parseRoute(missUrl, basePath, tables);
+});
+
+const listRoute = parseRoute(listUrl, basePath, tables)!;
+
+Deno.bench('resolveAction: GET list', () => {
+  resolveAction(listRoute, 'GET');
+});
+
+// 4 plugins × 5 routes = 20 registered routes; the match hits the last
+// route of the last plugin, so this measures the worst-case scan.
+const plugins: PluginConfig[] = Array.from({ length: 4 }, (_, p) => ({
+  name: `plugin${p}`,
+  routes: Array.from({ length: 5 }, (_, r) => ({
+    pattern: `:table/:id/route${r}`,
+    methods: ['GET' as const],
+    handler: () => new Response('ok'),
+  })),
+}));
+const pluginUrl = new URL('http://localhost/admin/plugin3/posts/1/route4');
+
+Deno.bench('matchPluginRoute: 20 routes, match last', () => {
+  matchPluginRoute(pluginUrl, basePath, 'GET', plugins);
+});

--- a/packages/cms/deno.jsonc
+++ b/packages/cms/deno.jsonc
@@ -13,7 +13,8 @@
       "LICENSE"
     ],
     "exclude": [
-      "tests/"
+      "tests/",
+      "benches/"
     ]
   },
   "imports": {

--- a/packages/core/benches/introspect_bench.ts
+++ b/packages/core/benches/introspect_bench.ts
@@ -1,0 +1,25 @@
+// Micro-benchmarks: schema introspection and field mapping.
+// These run at handler init (or per-request when uncached), so they set the
+// cold-start floor for the CMS. Run with: deno task bench
+
+import {
+  introspectFullSchema,
+  introspectTable,
+  mapColumnsToFields,
+} from '../mod.ts';
+import * as schema from '../tests/fixtures/schema-pg.ts';
+import { users } from '../tests/fixtures/schema-pg.ts';
+
+const usersInfo = introspectTable(users);
+
+Deno.bench('introspectFullSchema: blog schema (6 tables + relations)', () => {
+  introspectFullSchema(schema);
+});
+
+Deno.bench('introspectTable: single table', () => {
+  introspectTable(users);
+});
+
+Deno.bench('mapColumnsToFields: single table', () => {
+  mapColumnsToFields(usersInfo.columns);
+});

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -17,7 +17,8 @@
       "LICENSE"
     ],
     "exclude": [
-      "extend/drizzle.d.ts"
+      "extend/drizzle.d.ts",
+      "benches/"
     ]
   }
 }

--- a/packages/ui/benches/render_bench.ts
+++ b/packages/ui/benches/render_bench.ts
@@ -1,0 +1,99 @@
+// Micro-benchmarks: HTML escaping and view rendering — pure string building
+// that dominates response bodies. Run with: deno task bench
+
+import { introspectTable, mapColumnsToFields } from '@hotsauce/core';
+import { uploads } from '../../core/tests/fixtures/schema-pg.ts';
+import { escapeHtml, html } from '../html.ts';
+import { listTable } from '../views/list.ts';
+import type { ListColumn, ListViewOptions } from '../views/list.ts';
+import { gridItems } from '../views/grid.ts';
+import type { GridThumbnail, GridViewOptions } from '../views/grid.ts';
+
+const mixedText =
+  'Hello <world> & "friends" — text with <b>markup</b> to escape';
+
+Deno.bench('escapeHtml: 60-char mixed string', () => {
+  escapeHtml(mixedText);
+});
+
+Deno.bench('html tagged template: small fragment', () => {
+  html`
+    <div class="card">
+      <h2>${'Title & <tag>'}</h2>
+      <p>${mixedText}</p>
+    </div>
+  `;
+});
+
+// Full list-view table render at increasing row counts.
+const listColumns: ListColumn[] = [
+  { key: 'id', label: 'Id' },
+  { key: 'title', label: 'Title' },
+  { key: 'status', label: 'Status' },
+  { key: 'published', label: 'Published' },
+  { key: 'createdAt', label: 'Created At' },
+];
+
+function makeRecords(count: number): Record<string, unknown>[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    title: `Post ${i} <with> markup & entities in the title text`,
+    status: i % 3 === 0 ? 'draft' : 'published',
+    published: i % 2 === 0,
+    createdAt: new Date(2026, 0, 1 + (i % 28)),
+  }));
+}
+
+const listOptions: ListViewOptions = {
+  baseUrl: '/admin/posts',
+  showEdit: true,
+  showDelete: true,
+  showView: true,
+  csrfToken: 'bench-csrf-token',
+};
+
+const rows25 = makeRecords(25);
+const rows100 = makeRecords(100);
+const rows1000 = makeRecords(1000);
+
+Deno.bench(
+  'listTable: 25 rows × 5 columns',
+  { group: 'list view render', baseline: true },
+  () => {
+    listTable(listColumns, rows25, listOptions);
+  },
+);
+
+Deno.bench('listTable: 100 rows × 5 columns', {
+  group: 'list view render',
+}, () => {
+  listTable(listColumns, rows100, listOptions);
+});
+
+Deno.bench('listTable: 1,000 rows × 5 columns', {
+  group: 'list view render',
+}, () => {
+  listTable(listColumns, rows1000, listOptions);
+});
+
+// Grid view with image thumbnails (media-library style page).
+const uploadFields = mapColumnsToFields(introspectTable(uploads).columns);
+const thumbnailField = uploadFields[0]!;
+
+const gridOptions: GridViewOptions = {
+  baseUrl: '/admin/uploads',
+  thumbnailField,
+  currentView: 'grid',
+  currentUrl: '/admin/uploads?view=grid',
+};
+
+const gridRecords = makeRecords(100);
+const thumbnails: GridThumbnail[] = gridRecords.map((r, i) => ({
+  id: r.id as number,
+  thumbnailUrl: i % 4 === 0 ? null : `/files/upload-${i}.jpg`,
+  label: `upload-${i}.jpg`,
+}));
+
+Deno.bench('gridItems: 100 thumbnails', () => {
+  gridItems(gridRecords, thumbnails, gridOptions);
+});

--- a/packages/ui/deno.jsonc
+++ b/packages/ui/deno.jsonc
@@ -18,7 +18,8 @@
       "LICENSE"
     ],
     "exclude": [
-      "tests/"
+      "tests/",
+      "benches/"
     ]
   }
 }


### PR DESCRIPTION
Part 1 of 3 (benchmark rollout: suite → CI → docs).

Adds a `Deno.bench` suite with two tiers:

- **Micro-benchmarks** (`packages/{core,cms,ui,auth}/benches/`): schema introspection, field mapping, route parsing/dispatch, policy WHERE building, per-row column filtering, HTML escaping, list/grid view rendering at 25/100/1,000 rows, JWT sign/verify, cookie parsing. Grouped baselines show row-count scaling.
- **E2E handler benchmarks** (`packages/cms/benches/handler_bench.ts`): full `Request → createCmsHandler → Response` cycles including body consumption — dashboard, list pages (25-row table and default/100-row pages over a 1,000-row table), detail, edit form, form-submit create (explicit `b.start()`/`b.end()` timers with cleanup outside the measured region), and a list request through JWT auth + row/column policies.

The e2e database is **in-memory `node:sqlite`** behind drizzle's `sqlite-proxy` driver (~30-line adapter in `bench_helpers.ts`) — no external services, no wasm startup, so the numbers isolate CMS overhead on top of a real SQL engine. Pre-flight checks fail at load time if any benched route errors, so the suite can never silently measure error pages.

Also:
- root `deno.jsonc`: `bench` config block with fine-grained permissions (mirrors the `test` block) + `bench` / `bench:json` tasks
- `packages/{core,ui,cms,auth}/deno.jsonc`: `benches/` added to `publish.exclude` (JSR dry-runs verified green)

Deliberately not benchmarked (rationale lands in BENCHMARKS.md in part 3): PBKDF2 (slow by design), TOTP (time-window dependent), worker startup (spawn noise), fs/s3 storage (I/O-bound).

**Verification:** `deno task bench` green under `-P`; two identical full-suite runs compared within ±3% noise (create bench ~13–16%); all 1,331 tests pass; fmt/lint/check green.

Sample numbers (Apple M1 Pro, Deno 2.8.3): full admin list page ~290 µs, dashboard ~70 µs, create ~340 µs, list with auth + policies ~510 µs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)