### PR TITLE
feat(ci): PR benchmark regression check + gh-pages trend chart

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,165 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+  # Weekly run keeps the gh-pages trend chart fresh even without merges
+  schedule:
+    - cron: '0 6 * * 1' # 6 AM UTC Mondays
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  # Same-runner A/B comparison: base ref and PR ref are benchmarked
+  # back-to-back on one runner, so run-to-run machine variance mostly
+  # cancels out of the ratios. Informational by default; set the repo
+  # variable BENCH_STRICT=true to make regressions fail the job.
+  bench-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Checkout base ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-ref
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            .deno_cache
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
+      - name: Run benchmarks (base)
+        working-directory: base-ref
+        run: |
+          # Base ref may predate the bench suite; treat that as "no baselines"
+          if deno task bench:json > "$RUNNER_TEMP/base.json"; then
+            echo "Base benchmarks captured"
+          else
+            echo '{"benches":[]}' > "$RUNNER_TEMP/base.json"
+            echo "Base ref has no runnable bench task; all benches will be reported as new"
+          fi
+
+      - name: Run benchmarks (PR)
+        run: deno task bench:json > "$RUNNER_TEMP/pr.json"
+
+      - name: Compare
+        run: |
+          deno run --allow-read scripts/bench/compare.ts \
+            "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" \
+            | tee "$RUNNER_TEMP/summary.md"
+          cat "$RUNNER_TEMP/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # Sticky comment: updated in place on each push to the PR.
+      # Skipped for fork PRs, where the token cannot write comments;
+      # the step summary above still carries the results.
+      - name: Comment on PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- bench-comparison -->';
+            const body = marker + '\n' +
+              fs.readFileSync(process.env.RUNNER_TEMP + '/summary.md', 'utf8');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      # Promotion path: flip the BENCH_STRICT repo variable to true once the
+      # comparison has proven flake-free, and regressions will fail the job.
+      - name: Strict gate
+        if: vars.BENCH_STRICT == 'true'
+        run: |
+          deno run --allow-read scripts/bench/compare.ts \
+            "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" --fail > /dev/null
+
+  # Trend tracking: results from main are stored on gh-pages by
+  # github-action-benchmark, which renders an interactive chart at
+  # https://hotsauce-team.github.io/hotsauce/bench/
+  bench-main:
+    if: github.event_name != 'pull_request' && github.repository == 'hotsauce-team/hotsauce'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            .deno_cache
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
+      - name: Run benchmarks
+        run: deno task bench:json > "$RUNNER_TEMP/bench.json"
+
+      - name: Convert to github-action-benchmark format
+        run: |
+          deno run --allow-read scripts/bench/convert_gha.ts \
+            "$RUNNER_TEMP/bench.json" > "$RUNNER_TEMP/gha.json"
+
+      - name: Store result and update trend chart
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: hotsauce-cms benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: ${{ runner.temp }}/gha.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench
+          auto-push: true
+          # Alert (as a commit comment) when a result is 50% slower than
+          # the previous main run; never fail the job on cross-run noise.
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/scripts/bench/compare.ts
+++ b/scripts/bench/compare.ts
@@ -1,0 +1,185 @@
+// Compare two `deno bench --json` runs (base vs PR) and emit a markdown
+// report. Designed for same-runner A/B comparison in CI.
+//
+// Usage:
+//   deno run --allow-read scripts/bench/compare.ts base.json pr.json \
+//     [--threshold 1.25] [--fail]
+//
+// A bench counts as a REGRESSION only when BOTH avg and p75 exceed the
+// threshold ratio — the dual criterion filters single-outlier flakes.
+// Benches present on only one side are reported informationally, never
+// failed. Exits non-zero only when regressions exist AND --fail is passed.
+
+interface BenchStats {
+  n: number;
+  avg: number;
+  p75: number;
+}
+
+interface BenchEntry {
+  origin: string;
+  group: string | null;
+  name: string;
+  results: Array<{ ok?: BenchStats }>;
+}
+
+function fail(message: string): never {
+  console.error(`compare: ${message}`);
+  Deno.exit(1);
+}
+
+/** Normalize origin to a checkout-independent key */
+function originKey(origin: string): string {
+  const match = origin.match(/packages\/.+$/);
+  return match ? match[0] : origin;
+}
+
+function parseBenches(raw: string, label: string): Map<string, BenchStats> {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw);
+  } catch {
+    fail(`${label}: not valid JSON`);
+  }
+  const benches = (doc as { benches?: unknown }).benches;
+  if (!Array.isArray(benches)) {
+    fail(`${label}: missing "benches" array (did \`deno bench --json\` change?)`);
+  }
+  const map = new Map<string, BenchStats>();
+  for (const bench of benches as BenchEntry[]) {
+    const ok = bench.results?.[0]?.ok;
+    if (!ok || typeof ok.avg !== 'number' || typeof ok.p75 !== 'number') {
+      continue;
+    }
+    const key = [originKey(bench.origin), bench.group ?? '', bench.name].join(
+      '|',
+    );
+    map.set(key, ok);
+  }
+  return map;
+}
+
+function formatNs(ns: number): string {
+  if (ns >= 1e6) return `${(ns / 1e6).toFixed(2)} ms`;
+  if (ns >= 1e3) return `${(ns / 1e3).toFixed(1)} µs`;
+  return `${ns.toFixed(0)} ns`;
+}
+
+function formatRatio(ratio: number): string {
+  const pct = (ratio - 1) * 100;
+  const sign = pct >= 0 ? '+' : '';
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+function displayName(key: string): string {
+  const [origin, group, name] = key.split('|');
+  const pkg = origin?.match(/packages\/([^/]+)\//)?.[1] ?? origin;
+  return [pkg, group, name].filter(Boolean).join(' / ');
+}
+
+if (import.meta.main) {
+  const args = [...Deno.args];
+  const failOnRegression = args.includes('--fail');
+  let threshold = 1.25;
+  const thresholdIdx = args.indexOf('--threshold');
+  if (thresholdIdx !== -1) {
+    threshold = Number(args[thresholdIdx + 1]);
+    if (!Number.isFinite(threshold) || threshold <= 1) {
+      fail('--threshold must be a number > 1');
+    }
+    args.splice(thresholdIdx, 2);
+  }
+  const files = args.filter((a) => a !== '--fail');
+  const [baseFile, prFile] = files;
+  if (!baseFile || !prFile) {
+    fail('usage: compare.ts <base.json> <pr.json> [--threshold 1.25] [--fail]');
+  }
+
+  const base = parseBenches(Deno.readTextFileSync(baseFile), 'base');
+  const pr = parseBenches(Deno.readTextFileSync(prFile), 'PR');
+
+  const rows: string[] = [];
+  const regressions: string[] = [];
+  const improvements: string[] = [];
+  const newBenches: string[] = [];
+  const removedBenches: string[] = [];
+
+  const keys = [...pr.keys()].sort();
+  for (const key of keys) {
+    const prStats = pr.get(key)!;
+    const baseStats = base.get(key);
+    const name = displayName(key);
+
+    if (!baseStats) {
+      newBenches.push(name);
+      continue;
+    }
+
+    const avgRatio = prStats.avg / baseStats.avg;
+    const p75Ratio = prStats.p75 / baseStats.p75;
+
+    let status = '';
+    if (avgRatio > threshold && p75Ratio > threshold) {
+      status = '🔴 regression';
+      regressions.push(name);
+    } else if (avgRatio < 1 / threshold && p75Ratio < 1 / threshold) {
+      status = '🟢 improvement';
+      improvements.push(name);
+    }
+
+    rows.push(
+      `| ${name} | ${formatNs(baseStats.avg)} | ${formatNs(prStats.avg)} | ${
+        formatRatio(avgRatio)
+      } | ${formatRatio(p75Ratio)} | ${status} |`,
+    );
+  }
+
+  for (const key of base.keys()) {
+    if (!pr.has(key)) removedBenches.push(displayName(key));
+  }
+
+  const lines: string[] = [];
+  lines.push('## Benchmark comparison (base vs PR, same runner)');
+  lines.push('');
+  if (regressions.length > 0) {
+    lines.push(
+      `⚠️ **${regressions.length} possible regression(s)** — avg AND p75 both >${
+        formatRatio(threshold)
+      } slower than base:`,
+    );
+    for (const name of regressions) lines.push(`- ${name}`);
+  } else {
+    lines.push(
+      `✅ No regressions (threshold: avg and p75 both >${
+        formatRatio(threshold)
+      }).`,
+    );
+  }
+  if (improvements.length > 0) {
+    lines.push('');
+    lines.push(`🎉 ${improvements.length} improvement(s):`);
+    for (const name of improvements) lines.push(`- ${name}`);
+  }
+  lines.push('');
+  lines.push('<details><summary>Full results</summary>');
+  lines.push('');
+  lines.push('| Benchmark | base avg | PR avg | Δ avg | Δ p75 | |');
+  lines.push('| --- | --- | --- | --- | --- | --- |');
+  lines.push(...rows);
+  lines.push('');
+  lines.push('</details>');
+  if (newBenches.length > 0) {
+    lines.push('');
+    lines.push(`New benches (no baseline): ${newBenches.join(', ')}`);
+  }
+  if (removedBenches.length > 0) {
+    lines.push('');
+    lines.push(`Removed benches: ${removedBenches.join(', ')}`);
+  }
+
+  console.log(lines.join('\n'));
+
+  if (regressions.length > 0 && failOnRegression) {
+    Deno.exit(1);
+  }
+}

--- a/scripts/bench/convert_gha.ts
+++ b/scripts/bench/convert_gha.ts
@@ -1,0 +1,89 @@
+// Convert `deno bench --json` output to github-action-benchmark's
+// customSmallerIsBetter format.
+//
+// Usage:
+//   deno bench -P --json > bench.json
+//   deno run --allow-read scripts/bench/convert_gha.ts bench.json > gha.json
+//
+// NOTE: `deno bench --json` is marked unstable, so this parses defensively
+// and fails loudly if the shape changes.
+
+interface BenchResultOk {
+  n: number;
+  avg: number;
+  p75: number;
+  p99: number;
+}
+
+interface BenchEntry {
+  origin: string;
+  group: string | null;
+  name: string;
+  results: Array<{ ok?: BenchResultOk }>;
+}
+
+interface GhaEntry {
+  name: string;
+  unit: string;
+  value: number;
+  extra: string;
+}
+
+function fail(message: string): never {
+  console.error(`convert_gha: ${message}`);
+  Deno.exit(1);
+}
+
+/** Shorten a bench origin file URL to "package / file" */
+export function shortOrigin(origin: string): string {
+  const match = origin.match(/packages\/([^/]+)\/benches\/([^/]+)\.ts$/);
+  if (match) return match[1]!;
+  return origin.replace(/^file:\/\//, '');
+}
+
+export function convert(raw: string): GhaEntry[] {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw);
+  } catch {
+    fail('input is not valid JSON');
+  }
+
+  const benches = (doc as { benches?: unknown }).benches;
+  if (!Array.isArray(benches)) {
+    fail('unexpected shape: missing "benches" array (did `deno bench --json` change?)');
+  }
+
+  const entries: GhaEntry[] = [];
+  for (const bench of benches as BenchEntry[]) {
+    if (typeof bench?.name !== 'string' || !Array.isArray(bench.results)) {
+      fail(`unexpected bench entry shape: ${JSON.stringify(bench).slice(0, 200)}`);
+    }
+    const ok = bench.results[0]?.ok;
+    if (!ok) continue; // skip failed benches; the bench run itself reports them
+    if (typeof ok.avg !== 'number' || typeof ok.p75 !== 'number') {
+      fail(`unexpected result shape for "${bench.name}"`);
+    }
+    const parts = [shortOrigin(bench.origin)];
+    if (bench.group) parts.push(bench.group);
+    parts.push(bench.name);
+    entries.push({
+      name: parts.join(' / '),
+      unit: 'ns/iter',
+      value: ok.avg,
+      extra: `p75: ${ok.p75} ns, p99: ${ok.p99} ns, n: ${ok.n}`,
+    });
+  }
+
+  if (entries.length === 0) {
+    fail('no successful bench results found in input');
+  }
+  return entries;
+}
+
+if (import.meta.main) {
+  const file = Deno.args[0];
+  if (!file) fail('usage: convert_gha.ts <deno-bench-json-file>');
+  const entries = convert(Deno.readTextFileSync(file));
+  console.log(JSON.stringify(entries, null, 2));
+}


### PR DESCRIPTION
Part 2 of 3, stacked on #92 (benchmark rollout: suite → CI → docs).

Adds `.github/workflows/bench.yml` with two jobs:

**`bench-pr`** (on `pull_request`): checks out the PR head and the base SHA side by side, runs `deno task bench:json` on both **back-to-back on the same runner** (so machine variance mostly cancels out of the ratios), and posts the comparison as a sticky PR comment + step summary via `scripts/bench/compare.ts`:

- A bench is flagged as a regression only when **both avg and p75** exceed 1.25× — the dual criterion filters single-outlier flakes.
- Benches new in the PR are reported informationally, never failed; a base ref without the bench task is treated as "no baselines".
- **Informational by default.** Set the repo variable `BENCH_STRICT=true` to make flagged regressions fail the job (intended only after observing the flake rate on a few no-op PRs).
- Comment step is skipped for fork PRs (read-only token); the step summary still carries the results.

**`bench-main`** (push to main + weekly cron + dispatch): converts results via `scripts/bench/convert_gha.ts` (`deno bench --json` → `customSmallerIsBetter`) and stores them with `benchmark-action/github-action-benchmark`, rendering a trend chart at https://hotsauce-team.github.io/hotsauce/bench/ with 150% alert comments (never failing the job on cross-run noise).

⚠️ **After merge:** enable GitHub Pages (serve from the `gh-pages` branch) in repo settings so the chart renders. `deno bench --json` is unstable, so both scripts parse defensively and fail loudly on shape changes.

**Verification:** two identical runs compare clean (no false positives); a synthetic 1.6× slowdown is correctly flagged; `--fail` exit codes verified. This PR itself exercises `bench-pr` against #92's branch. A deliberate-slowdown draft PR is the remaining end-to-end test before considering `BENCH_STRICT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)