### PR TITLE
test: verify bench regression detection (do not merge)

### DIFF
--- a/packages/cms/router.ts
+++ b/packages/cms/router.ts
@@ -130,6 +130,12 @@ export function parseRoute(
   basePath: string,
   tables: IntrospectedTable[],
 ): ParsedRoute | null {
+  // TEMP: artificial slowdown to verify the bench-pr regression check.
+  // DO NOT MERGE.
+  let benchSlowdownAcc = 0;
+  for (let i = 0; i < 20000; i++) benchSlowdownAcc += i;
+  if (benchSlowdownAcc < 0) return null;
+
   // Normalize paths (remove trailing slashes)
   const normalizedBase = basePath.replace(/\/+$/, '');
   const pathname = url.pathname.replace(/\/+$/, '') || '/';


### PR DESCRIPTION
Throwaway draft PR: adds a deliberate busy-loop to `parseRoute` to confirm the `bench-pr` job flags a genuine regression on real CI runners (the final verification step from the benchmark rollout).

Expected: the sticky benchmark comment flags the four `parseRoute` benches as 🔴 regressions. Will be closed once confirmed — **do not merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)